### PR TITLE
Refactor: Encapsulate shared memory functions into class

### DIFF
--- a/dll_src/shared_memory.cpp
+++ b/dll_src/shared_memory.cpp
@@ -1,63 +1,47 @@
 #include "shared_memory.hpp"
 
-#include <map>
-#include <mutex>
-#include <unordered_map>
 #include <vector>
 
-// Old version.
-// static std::unordered_map<int32_t, std::map<int32_t, AviUtl::SharedMemoryInfo *>> g_handle_map;
-static std::unordered_map<int32_t, std::map<int32_t, HANDLE>> g_handle_map;
-static std::mutex g_mutex;
+std::mutex SharedMemory::mutex;
 
-// AviUtl::SharedMemoryInfo *
-HANDLE
-SharedMemoryInternal::get_shared_mem_handle(int32_t key1, int32_t key2) {
-    std::lock_guard<std::mutex> lock(g_mutex);
+SharedMemory::SharedMemory() {}
+SharedMemory::~SharedMemory() { cleanup_all_handle_impl(); }
 
-    auto it = g_handle_map.find(key1);
-    if (it == g_handle_map.end())
-        return nullptr;
+void
+SharedMemory::cleanup_all_handle_impl() {
+    for (auto &[_, inner_map] : handle_map) {
+        for (auto &[__, handle] : inner_map) {
+            if (handle && handle != INVALID_HANDLE_VALUE)
+                CloseHandle(handle);
+        }
 
-    auto &handles = it->second;
-    auto idx_it = handles.find(key2);
-    if (idx_it == handles.end())
-        return nullptr;
+        inner_map.clear();
+    }
 
-    return idx_it->second;
+    handle_map.clear();
 }
 
 void
-SharedMemoryInternal::set_shared_mem_handle(int32_t key1, int32_t key2, HANDLE handle) {
-    std::lock_guard<std::mutex> lock(g_mutex);
-
-    auto &handles = g_handle_map[key1];
-    handles[key2] = handle;
+SharedMemory::cleanup_all_handle() {
+    std::lock_guard<std::mutex> lock(mutex);
+    cleanup_all_handle_impl();
 }
 
 void
-cleanup_all(uint16_t script_id) {
-    std::lock_guard<std::mutex> lock(g_mutex);
+SharedMemory::cleanup_for_id(uint16_t object_id) {
+    std::lock_guard<std::mutex> lock(mutex);
 
-    uint32_t target_bits = static_cast<uint32_t>(script_id) & 0x3;
+    uint32_t target_bits = static_cast<uint32_t>(object_id & 0x3FFF);
     std::vector<int32_t> keys_to_erase;
 
-    for (auto &[key1, inner_map] : g_handle_map) {
-        uint32_t source_bits = static_cast<uint32_t>(key1) >> 30;
+    for (auto &[key1, inner_map] : handle_map) {
+        uint32_t source_bits = static_cast<uint32_t>(key1 & 0x3FFF);
         if (source_bits != target_bits)
             continue;
 
         for (auto &[__, handle] : inner_map) {
             if (handle && handle != INVALID_HANDLE_VALUE)
                 CloseHandle(handle);
-
-            // Old Version.
-            /*
-            AviUtl::SharedMemoryInfo* handle = it2->second;
-            if (handle != nullptr) {
-                obj_utils.delete_shared_mem(key1, handle);
-            }
-            */
         }
 
         inner_map.clear();
@@ -65,75 +49,36 @@ cleanup_all(uint16_t script_id) {
     }
 
     for (int32_t key1 : keys_to_erase) {
-        g_handle_map.erase(key1);
-    }
-}
-
-void
-cleanup_for_id(uint16_t script_id, uint16_t object_id) {
-    std::lock_guard<std::mutex> lock(g_mutex);
-
-    uint32_t id_t = (static_cast<uint32_t>(script_id & 0x3) << 30);
-    uint32_t id_b = static_cast<uint32_t>(object_id & 0x3FFF);
-    uint32_t target_bits = id_t | id_b;
-
-    std::vector<int32_t> keys_to_erase;
-
-    for (auto &[key1, inner_map] : g_handle_map) {
-        uint32_t source_bits = static_cast<uint32_t>(key1 & (0x3 << 30 | 0x3FFF));
-        if (source_bits != target_bits)
-            continue;
-
-        for (auto &[__, handle] : inner_map) {
-            if (handle && handle != INVALID_HANDLE_VALUE)
-                CloseHandle(handle);
-
-            // Old Version.
-            /*
-            AviUtl::SharedMemoryInfo *handle = it2->second;
-            if (handle != nullptr) {
-                obj_utils.delete_shared_mem(key1, handle);
-            }
-            */
-        }
-
-        inner_map.clear();
-        keys_to_erase.push_back(key1);
-    }
-
-    for (int32_t key1 : keys_to_erase) {
-        g_handle_map.erase(key1);
+        handle_map.erase(key1);
     }
 }
 
 bool
-handle_exists(int32_t key1) {
-    std::lock_guard<std::mutex> lock(g_mutex);
+SharedMemory::handle_exists(int32_t key1) const {
+    std::lock_guard<std::mutex> lock(mutex);
 
-    if (g_handle_map.find(key1) != g_handle_map.end())
+    if (handle_map.find(key1) != handle_map.end())
         return true;
     else
         return false;
 }
 
-static void
-cleanup_all_handle() {
-    for (auto &[_, inner_map] : g_handle_map) {
-        for (auto &[__, handle] : inner_map) {
-            if (handle && handle != INVALID_HANDLE_VALUE)
-                CloseHandle(handle);
-        }
+HANDLE
+SharedMemory::get_shared_mem_handle(int32_t key1, int32_t key2) const {
+    auto it_key1 = handle_map.find(key1);
+    if (it_key1 == handle_map.end())
+        return nullptr;
 
-        inner_map.clear();
-    }
+    auto &handles = it_key1->second;
+    auto it_key2 = handles.find(key2);
+    if (it_key2 == handles.end())
+        return nullptr;
 
-    g_handle_map.clear();
+    return it_key2->second;
 }
 
-extern "C" BOOL APIENTRY
-DllMain([[maybe_unused]] HMODULE hModule, DWORD reason, LPVOID) {
-    if (reason == DLL_PROCESS_DETACH) {
-        cleanup_all_handle();
-    }
-    return TRUE;
+void
+SharedMemory::set_shared_mem_handle(int32_t key1, int32_t key2, HANDLE handle) {
+    auto &handles = handle_map[key1];
+    handles[key2] = handle;
 }

--- a/dll_src/shared_memory.hpp
+++ b/dll_src/shared_memory.hpp
@@ -2,120 +2,88 @@
 
 #include <cstdint>
 #include <cstring>
+#include <map>
+#include <mutex>
+#include <unordered_map>
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-// Old versions probably have a bug similar to exedit0.93 test.
+class SharedMemory {
+public:
+    SharedMemory();
+    ~SharedMemory();
 
-// Old Version.
-/*
-#define NOMINMAX
-#include <exedit.hpp>
+    void cleanup_all_handle();
+    void cleanup_for_id(uint16_t object_id);
+    bool handle_exists(int32_t key1) const;
 
-#include "aul_utils.hpp"
-*/
+    template <typename T>
+    void write(int32_t key1, int32_t key2, const T &val) {
+        std::lock_guard<std::mutex> lock(mutex);
 
-namespace SharedMemoryInternal {
-HANDLE
-get_shared_mem_handle(int32_t key1, int32_t key2);
-void
-set_shared_mem_handle(int32_t key1, int32_t key2, HANDLE handle);
-
-// Old Version.
-/*
-AviUtl::SharedMemoryInfo *
-get_shared_mem_handle(int32_t key1, int32_t key2);
-void
-set_shared_mem_handle(int32_t key1, int32_t key2, AviUtl::SharedMemoryInfo *handle);
-*/
-}  // namespace SharedMemoryInternal
-
-template <typename T>
-inline void
-create_shared_mem(int32_t key1, int32_t key2, const T &val) {
-    size_t size = sizeof(T);
-    if (size == 0)
-        return;
-
-    HANDLE old_handle = SharedMemoryInternal::get_shared_mem_handle(key1, key2);
-    HANDLE new_handle = nullptr;
-
-    if (old_handle == nullptr) {
-        new_handle = CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, size, nullptr);
-        if (new_handle == nullptr)
+        size_t size = sizeof(T);
+        if (size == 0)
             return;
-    } else {
-        new_handle = old_handle;
+
+        HANDLE old_handle = get_shared_mem_handle(key1, key2);
+        HANDLE new_handle = nullptr;
+        bool is_newly_created = false;
+
+        if (old_handle == nullptr) {
+            new_handle = CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, size, nullptr);
+            if (new_handle == nullptr)
+                return;
+
+            is_newly_created = true;
+        } else {
+            new_handle = old_handle;
+        }
+
+        T *ptr = static_cast<T *>(MapViewOfFile(new_handle, FILE_MAP_ALL_ACCESS, 0, 0, size));
+        if (ptr == nullptr) {
+            if (is_newly_created)
+                CloseHandle(new_handle);
+
+            return;
+        }
+
+        std::memcpy(ptr, &val, size);
+        UnmapViewOfFile(ptr);
+
+        if (is_newly_created)
+            set_shared_mem_handle(key1, key2, new_handle);
     }
 
-    T *ptr = static_cast<T *>(MapViewOfFile(new_handle, FILE_MAP_ALL_ACCESS, 0, 0, size));
-    if (ptr == nullptr) {
-        if (new_handle != old_handle)
-            CloseHandle(new_handle);
-        return;
+    template <typename T>
+    bool read(int32_t key1, int32_t key2, T &val) const {
+        std::lock_guard<std::mutex> lock(mutex);
+
+        size_t size = sizeof(T);
+        if (size == 0)
+            return false;
+
+        HANDLE handle = get_shared_mem_handle(key1, key2);
+        if (handle == nullptr)
+            return false;
+
+        T *ptr = static_cast<T *>(MapViewOfFile(handle, FILE_MAP_ALL_ACCESS, 0, 0, size));
+        if (ptr == nullptr) {
+            return false;
+        }
+
+        std::memcpy(&val, ptr, size);
+        UnmapViewOfFile(ptr);
+
+        return true;
     }
 
-    std::memcpy(ptr, &val, size);
-    UnmapViewOfFile(ptr);
+private:
+    static std::mutex mutex;
 
-    if (new_handle != old_handle && old_handle != nullptr)
-        CloseHandle(old_handle);
+    std::unordered_map<int32_t, std::map<int32_t, HANDLE>> handle_map;
 
-    SharedMemoryInternal::set_shared_mem_handle(key1, key2, new_handle);
-
-    // Old Version.
-    /*
-    AviUtl::SharedMemoryInfo *handle = SharedMemoryInternal::get_shared_mem_handle(key1, key2);
-    if (handle != nullptr) {
-        obj_utils.delete_shared_mem(key1, handle);
-    }
-
-    if (obj_utils.create_shared_mem(key1, key2, &handle, val))
-        SharedMemoryInternal::set_shared_mem_handle(key1, key2, handle);
-    */
-}
-
-template <typename T>
-inline bool
-get_shared_mem(int32_t key1, int32_t key2, T &val) {
-    size_t size = sizeof(T);
-    if (size == 0)
-        return false;
-
-    HANDLE handle = SharedMemoryInternal::get_shared_mem_handle(key1, key2);
-    if (handle == nullptr)
-        return false;
-
-    T *ptr = static_cast<T *>(MapViewOfFile(handle, FILE_MAP_ALL_ACCESS, 0, 0, size));
-    if (ptr == nullptr) {
-        return false;
-    }
-
-    std::memcpy(&val, ptr, size);
-    UnmapViewOfFile(ptr);
-
-    return true;
-
-    // Old Version.
-    /*
-    AviUtl::SharedMemoryInfo *handle = SharedMemoryInternal::get_shared_mem_handle(key1, key2);
-    if (handle != nullptr) {
-        return obj_utils.get_shared_mem(key1, key2, handle, val);
-    }
-    return false;
-    */
-}
-
-void
-cleanup_all(uint16_t script_id);
-
-void
-cleanup_for_id(uint16_t script_id, uint16_t object_id);
-
-bool
-handle_exists(int32_t key1);
-
-// DLL Entry.
-extern "C" BOOL APIENTRY
-DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved);
+    HANDLE get_shared_mem_handle(int32_t key1, int32_t key2) const;
+    void set_shared_mem_handle(int32_t key1, int32_t key2, HANDLE handle);
+    void cleanup_all_handle_impl();
+};

--- a/dll_src/shared_memory.hpp
+++ b/dll_src/shared_memory.hpp
@@ -11,27 +11,30 @@
 
 class SharedMemory {
 public:
-    SharedMemory();
+    SharedMemory(uint32_t block_bits = 0u);
     ~SharedMemory();
 
     void cleanup_all_handle();
-    void cleanup_for_id(uint16_t object_id);
-    bool handle_exists(int32_t key1) const;
+    void cleanup_for_key1_mask(uint32_t match_bits, uint32_t mask);
+    bool has_key1(uint32_t key1) const;
+    bool has_key_pair(uint32_t key1, uint32_t key2) const;
 
     template <typename T>
-    void write(int32_t key1, int32_t key2, const T &val) {
+    void write(uint32_t key1, uint32_t key2, const T &val) {
         std::lock_guard<std::mutex> lock(mutex);
 
-        size_t size = sizeof(T);
-        if (size == 0)
-            return;
+        const size_t size = sizeof(T);
+        const size_t total_size = size << block_bits;
 
-        HANDLE old_handle = get_shared_mem_handle(key1, key2);
+        uint32_t block_id, block_offset;
+        calc_block_pos(key2, block_id, block_offset);
+
+        HANDLE old_handle = get_shared_mem_handle(key1, block_id);
         HANDLE new_handle = nullptr;
         bool is_newly_created = false;
 
         if (old_handle == nullptr) {
-            new_handle = CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, size, nullptr);
+            new_handle = CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, total_size, nullptr);
             if (new_handle == nullptr)
                 return;
 
@@ -40,7 +43,7 @@ public:
             new_handle = old_handle;
         }
 
-        T *ptr = static_cast<T *>(MapViewOfFile(new_handle, FILE_MAP_ALL_ACCESS, 0, 0, size));
+        T *ptr = static_cast<T *>(MapViewOfFile(new_handle, FILE_MAP_ALL_ACCESS, 0, 0, total_size));
         if (ptr == nullptr) {
             if (is_newly_created)
                 CloseHandle(new_handle);
@@ -48,31 +51,33 @@ public:
             return;
         }
 
-        std::memcpy(ptr, &val, size);
+        std::memcpy(ptr + block_offset, &val, size);
         UnmapViewOfFile(ptr);
 
         if (is_newly_created)
-            set_shared_mem_handle(key1, key2, new_handle);
+            set_shared_mem_handle(key1, block_id, new_handle);
     }
 
     template <typename T>
-    bool read(int32_t key1, int32_t key2, T &val) const {
+    bool read(uint32_t key1, uint32_t key2, T &val) const {
         std::lock_guard<std::mutex> lock(mutex);
 
-        size_t size = sizeof(T);
-        if (size == 0)
-            return false;
+        const size_t size = sizeof(T);
+        const size_t total_size = size << block_bits;
 
-        HANDLE handle = get_shared_mem_handle(key1, key2);
+        uint32_t block_id, block_offset;
+        calc_block_pos(key2, block_id, block_offset);
+
+        HANDLE handle = get_shared_mem_handle(key1, block_id);
         if (handle == nullptr)
             return false;
 
-        T *ptr = static_cast<T *>(MapViewOfFile(handle, FILE_MAP_ALL_ACCESS, 0, 0, size));
+        T *ptr = static_cast<T *>(MapViewOfFile(handle, FILE_MAP_ALL_ACCESS, 0, 0, total_size));
         if (ptr == nullptr) {
             return false;
         }
 
-        std::memcpy(&val, ptr, size);
+        std::memcpy(&val, ptr + block_offset, size);
         UnmapViewOfFile(ptr);
 
         return true;
@@ -81,9 +86,17 @@ public:
 private:
     static std::mutex mutex;
 
-    std::unordered_map<int32_t, std::map<int32_t, HANDLE>> handle_map;
+    std::unordered_map<uint32_t, std::map<uint32_t, HANDLE>> handle_map;
+    uint32_t block_bits;
 
-    HANDLE get_shared_mem_handle(int32_t key1, int32_t key2) const;
-    void set_shared_mem_handle(int32_t key1, int32_t key2, HANDLE handle);
-    void cleanup_all_handle_impl();
+    void calc_block_pos(uint32_t key, uint32_t &block_id, uint32_t &block_offset) const;
+    HANDLE get_shared_mem_handle(uint32_t key1, uint32_t block_id) const;
+    void set_shared_mem_handle(uint32_t key1, uint32_t block_id, HANDLE handle);
+    void cleanup_all_handle_impl() noexcept;
 };
+
+inline void
+SharedMemory::calc_block_pos(uint32_t key, uint32_t &block_id, uint32_t &block_offset) const {
+    block_id = key >> block_bits;                    // key / (2 ^ block_bits)
+    block_offset = key & ((1u << block_bits) - 1u);  // key % (2 ^ block_bits)
+}


### PR DESCRIPTION
Closes #3 

This pull request refactors the existing shared memory-related functions by encapsulating them into a dedicated class. The new design improves code readability, modularity, and maintainability.

- Created a new class `SharedMemory` to handle shared memory logic.

- Migrated relevant functions into member methods.

- Updated existing code to use the new class interface.

- Increases the maximum number of supported individual objects  (`obj.index`) from 2^16 (65,536) to 2^18 (262,144)

The number of handles stored in the `std::map` is planned to be reduced by batching multiple frames into a single array, since the per-frame data is lightweight.