### PR TITLE
Feature: Use 3×3 matrices for coordinate transformations

### DIFF
--- a/dll_src/aul_utils.cpp
+++ b/dll_src/aul_utils.cpp
@@ -66,10 +66,8 @@ ObjectUtils::ObjectUtils() :
     efp->aviutl_exfunc->get_sys_info(nullptr, &sys_info);
     max_w = sys_info.max_w;
     max_h = sys_info.max_h;
-
-    if (sys_info.build != 11003) {
+    if (sys_info.build != 11003)
         throw std::runtime_error("AviUtl v1.10 is required.");
-    }
 }
 
 float

--- a/dll_src/aul_utils.cpp
+++ b/dll_src/aul_utils.cpp
@@ -7,7 +7,7 @@
 #include "aul_utils.hpp"
 
 AulMemory::AulMemory() : efp(nullptr), efpip(nullptr), loaded_filter_table(nullptr), camera_mode(-1), is_saving(false) {
-    static uintptr_t exedit_base = get_exedit_base();
+    static std::uintptr_t exedit_base = get_exedit_base();
 
     efp = get_exedit_filter_ptr(exedit_base);
     if (!efp)
@@ -29,14 +29,14 @@ AulMemory::AulMemory() : efp(nullptr), efpip(nullptr), loaded_filter_table(nullp
     if (camera_mode < 0)
         throw std::runtime_error("Failed to retrieve camera mode.");
 
-    int32_t raw_saving_flag = get_is_saving(exedit_base);
+    std::int32_t raw_saving_flag = get_is_saving(exedit_base);
     if ((raw_saving_flag & ~1) != 0)
         throw std::runtime_error("Failed to retrieve is saving status.");
 
     is_saving = (raw_saving_flag & 1) != 0;
 }
 
-uintptr_t
+std::uintptr_t
 AulMemory::get_exedit_base() const {
     static HMODULE handle = []() -> HMODULE {
         HMODULE h = ::GetModuleHandle(_T("exedit.auf"));
@@ -45,9 +45,9 @@ AulMemory::get_exedit_base() const {
         return h;
     }();
 
-    uintptr_t base = reinterpret_cast<uintptr_t>(handle);
+    std::uintptr_t base = reinterpret_cast<std::uintptr_t>(handle);
 
-    static uintptr_t exedit_base = [base, this]() -> uintptr_t {
+    static std::uintptr_t exedit_base = [base, this]() -> std::uintptr_t {
         if (!check_exedit_version(base))
             throw std::runtime_error("ExEdit (exedit.auf) v0.92 is required.");
         return base;
@@ -71,7 +71,7 @@ ObjectUtils::ObjectUtils() :
 }
 
 float
-ObjectUtils::calc_track_val(TrackName track_name, int32_t offset_frame, OffsetType offset_type) const {
+ObjectUtils::calc_track_val(TrackName track_name, std::int32_t offset_frame, OffsetType offset_type) const {
     if (!ExEdit::is_valid(curr_ofi))
         return 0.0f;
 
@@ -79,12 +79,12 @@ ObjectUtils::calc_track_val(TrackName track_name, int32_t offset_frame, OffsetTy
     if (!curr_proc_efp->track_gui)
         return 0.0f;
 
-    int32_t val;
-    int32_t frame = offset_type == OffsetType::Current
-                          ? std::clamp(efpip->frame_num + offset_frame, efpip->objectp->frame_begin,
-                                       efpip->objectp->frame_end)
-                          : std::clamp(efpip->objectp->frame_begin + offset_frame, efpip->objectp->frame_begin,
-                                       efpip->objectp->frame_end);
+    std::int32_t val;
+    std::int32_t frame = offset_type == OffsetType::Current
+                               ? std::clamp(efpip->frame_num + offset_frame, efpip->objectp->frame_begin,
+                                            efpip->objectp->frame_end)
+                               : std::clamp(efpip->objectp->frame_begin + offset_frame, efpip->objectp->frame_begin,
+                                            efpip->objectp->frame_end);
     int track_idx = -1;
     float track_denom = 1e-1f;
 

--- a/dll_src/aul_utils.cpp
+++ b/dll_src/aul_utils.cpp
@@ -58,7 +58,7 @@ AulMemory::get_exedit_base() const {
 
 ObjectUtils::ObjectUtils() :
     AulMemory(),
-    curr_ofi(efpip ? get_curr_proc(efpip) : create_object_filter_index(0, 0)),
+    curr_ofi(efpip ? get_curr_proc(efpip) : create_ofi(0, 0)),
     curr_object_idx(ExEdit::object(curr_ofi)),
     curr_filter_idx(ExEdit::filter(curr_ofi)),
     local_frame(efpip ? efpip->frame_num - efpip->objectp->frame_begin : 0) {

--- a/dll_src/aul_utils.hpp
+++ b/dll_src/aul_utils.hpp
@@ -36,8 +36,8 @@ protected:
     int32_t camera_mode;
     bool is_saving;
 
-    using GetCurrentProcessing = ExEdit::ObjectFilterIndex(__cdecl *)(ExEdit::FilterProcInfo *);
-    GetCurrentProcessing get_curr_proc;
+    using get_current_processing_fn = ExEdit::ObjectFilterIndex(__cdecl *)(ExEdit::FilterProcInfo *);
+    get_current_processing_fn get_curr_proc;
 
 private:
     static constexpr uintptr_t VERSION_OFFSET = 0x4d726;
@@ -53,7 +53,7 @@ private:
     [[nodiscard]] ExEdit::Filter *get_exedit_filter_ptr(uintptr_t exedit_base) const noexcept;
     [[nodiscard]] ExEdit::FilterProcInfo *get_exedit_filter_proc_info_ptr(uintptr_t exedit_base) const noexcept;
     [[nodiscard]] ExEdit::Filter **get_loaded_filter_table(uintptr_t exedit_base) const noexcept;
-    [[nodiscard]] GetCurrentProcessing get_get_curr_proc(uintptr_t exedit_base) const noexcept;
+    [[nodiscard]] get_current_processing_fn get_get_curr_proc(uintptr_t exedit_base) const noexcept;
     [[nodiscard]] int32_t get_camera_mode(uintptr_t exedit_base) const noexcept;
     [[nodiscard]] int32_t get_is_saving(uintptr_t exedit_base) const noexcept;
 };
@@ -138,9 +138,9 @@ AulMemory::get_loaded_filter_table(uintptr_t exedit_base) const noexcept {
     return reinterpret_cast<ExEdit::Filter **>(exedit_base + LOADED_FILTER_TABLE_OFFSET);
 }
 
-inline AulMemory::GetCurrentProcessing
+inline AulMemory::get_current_processing_fn
 AulMemory::get_get_curr_proc(uintptr_t exedit_base) const noexcept {
-    return reinterpret_cast<GetCurrentProcessing>(exedit_base + GET_CURR_PROC_OFFSET);
+    return reinterpret_cast<get_current_processing_fn>(exedit_base + GET_CURR_PROC_OFFSET);
 }
 
 inline int32_t

--- a/dll_src/aul_utils.hpp
+++ b/dll_src/aul_utils.hpp
@@ -30,187 +30,189 @@ public:
     AulMemory &operator=(const AulMemory &) = delete;
 
 protected:
-    using get_curr_proc_fn = ExEdit::ObjectFilterIndex(__cdecl *)(ExEdit::FilterProcInfo *);
+    using GetCurrProcFn = ExEdit::ObjectFilterIndex(__cdecl *)(ExEdit::FilterProcInfo *);
 
     ExEdit::Filter *efp;
     ExEdit::FilterProcInfo *efpip;
     ExEdit::Filter **loaded_filter_table;
-    int32_t camera_mode;
+    std::int32_t camera_mode;
     bool is_saving;
-    get_curr_proc_fn get_curr_proc;
+    GetCurrProcFn get_curr_proc;
 
 private:
-    static constexpr uintptr_t VERSION_OFFSET = 0x4d726;
-    static constexpr uintptr_t EFPP_OFFSET = 0x1b2b10;
-    static constexpr uintptr_t EFPIPP_OFFSET = 0x1b2b20;
-    static constexpr uintptr_t LOADED_FILTER_TABLE_OFFSET = 0x187c98;
-    static constexpr uintptr_t GET_CURR_PROC_OFFSET = 0x047ba0;
-    static constexpr uintptr_t CAMERA_MODE_OFFSET = 0x013596c;
-    static constexpr uintptr_t IS_SAVING_OFFSET = 0x1a52e4;
+    struct Offsets {
+        static constexpr std::uintptr_t Version = 0x4d726;
+        static constexpr std::uintptr_t ScriptEfp = 0x1b2b10;
+        static constexpr std::uintptr_t ScriptEfpip = 0x1b2b20;
+        static constexpr std::uintptr_t LoadedFilterTable = 0x187c98;
+        static constexpr std::uintptr_t GetCurrProc = 0x047ba0;
+        static constexpr std::uintptr_t CameraMode = 0x013596c;
+        static constexpr std::uintptr_t IsSaving = 0x1a52e4;
+    };
 
-    [[nodiscard]] uintptr_t get_exedit_base() const;
-    [[nodiscard]] bool check_exedit_version(uintptr_t exedit_base) const noexcept;
-    [[nodiscard]] ExEdit::Filter *get_exedit_filter_ptr(uintptr_t exedit_base) const noexcept;
-    [[nodiscard]] ExEdit::FilterProcInfo *get_exedit_filter_proc_info_ptr(uintptr_t exedit_base) const noexcept;
-    [[nodiscard]] ExEdit::Filter **get_loaded_filter_table(uintptr_t exedit_base) const noexcept;
-    [[nodiscard]] get_curr_proc_fn get_get_curr_proc(uintptr_t exedit_base) const noexcept;
-    [[nodiscard]] int32_t get_camera_mode(uintptr_t exedit_base) const noexcept;
-    [[nodiscard]] int32_t get_is_saving(uintptr_t exedit_base) const noexcept;
+    [[nodiscard]] std::uintptr_t get_exedit_base() const;
+    [[nodiscard]] bool check_exedit_version(std::uintptr_t exedit_base) const noexcept;
+    [[nodiscard]] ExEdit::Filter *get_exedit_filter_ptr(std::uintptr_t exedit_base) const noexcept;
+    [[nodiscard]] ExEdit::FilterProcInfo *get_exedit_filter_proc_info_ptr(std::uintptr_t exedit_base) const noexcept;
+    [[nodiscard]] ExEdit::Filter **get_loaded_filter_table(std::uintptr_t exedit_base) const noexcept;
+    [[nodiscard]] GetCurrProcFn get_get_curr_proc(std::uintptr_t exedit_base) const noexcept;
+    [[nodiscard]] std::int32_t get_camera_mode(std::uintptr_t exedit_base) const noexcept;
+    [[nodiscard]] std::int32_t get_is_saving(std::uintptr_t exedit_base) const noexcept;
 };
 
 class ObjectUtils : public AulMemory {
 public:
-    using geo = ExEdit::FilterProcInfo::Geometry;
-    using obj_filter_idx = ExEdit::ObjectFilterIndex;
+    using Geo = ExEdit::FilterProcInfo::Geometry;
+    using ObjFilterIdx = ExEdit::ObjectFilterIndex;
 
     // Constructors.
     ObjectUtils();
     ObjectUtils(const ObjectUtils &) = delete;
     ObjectUtils &operator=(const ObjectUtils &) = delete;
 
-    [[nodiscard]] constexpr int32_t get_frame_begin() const noexcept { return efpip->objectp->frame_begin; }
-    [[nodiscard]] constexpr int32_t get_frame_end() const noexcept { return efpip->objectp->frame_end; }
-    [[nodiscard]] constexpr int32_t get_frame_num() const noexcept { return efpip->frame_num; }
-    [[nodiscard]] constexpr int32_t get_local_frame() const noexcept { return local_frame; }
-    [[nodiscard]] constexpr int32_t get_obj_w() const noexcept { return efpip->obj_w; }
-    [[nodiscard]] constexpr int32_t get_obj_h() const noexcept { return efpip->obj_h; }
-    [[nodiscard]] constexpr const geo &get_obj_data() const noexcept { return efpip->obj_data; }
-    [[nodiscard]] constexpr bool get_is_saving() const noexcept { return is_saving; }
-    [[nodiscard]] constexpr uint16_t get_curr_object_idx() const noexcept { return curr_object_idx; }
-    [[nodiscard]] constexpr int32_t get_obj_index() const noexcept { return efpip->obj_index; }
-    [[nodiscard]] constexpr int32_t get_obj_num() const noexcept { return efpip->obj_num; }
-    [[nodiscard]] constexpr int32_t get_camera_mode() const noexcept { return camera_mode; }
-    [[nodiscard]] constexpr int32_t get_max_w() const noexcept { return max_w; }
-    [[nodiscard]] constexpr int32_t get_max_h() const noexcept { return max_h; }
+    [[nodiscard]] constexpr const std::int32_t &get_frame_begin() const noexcept { return efpip->objectp->frame_begin; }
+    [[nodiscard]] constexpr const std::int32_t &get_frame_end() const noexcept { return efpip->objectp->frame_end; }
+    [[nodiscard]] constexpr const std::int32_t &get_frame_num() const noexcept { return efpip->frame_num; }
+    [[nodiscard]] constexpr const std::int32_t &get_local_frame() const noexcept { return local_frame; }
+    [[nodiscard]] constexpr const std::int32_t &get_obj_w() const noexcept { return efpip->obj_w; }
+    [[nodiscard]] constexpr const std::int32_t &get_obj_h() const noexcept { return efpip->obj_h; }
+    [[nodiscard]] constexpr const Geo &get_obj_data() const noexcept { return efpip->obj_data; }
+    [[nodiscard]] constexpr const bool &get_is_saving() const noexcept { return is_saving; }
+    [[nodiscard]] constexpr const std::uint16_t &get_curr_object_idx() const noexcept { return curr_object_idx; }
+    [[nodiscard]] constexpr const std::int32_t &get_obj_index() const noexcept { return efpip->obj_index; }
+    [[nodiscard]] constexpr const std::int32_t &get_obj_num() const noexcept { return efpip->obj_num; }
+    [[nodiscard]] constexpr const std::int32_t &get_camera_mode() const noexcept { return camera_mode; }
+    [[nodiscard]] constexpr const std::int32_t &get_max_w() const noexcept { return max_w; }
+    [[nodiscard]] constexpr const std::int32_t &get_max_h() const noexcept { return max_h; }
 
-    constexpr void set_obj_w(int32_t w) noexcept { efpip->obj_w = std::clamp(w, 0, max_w); }
-    constexpr void set_obj_h(int32_t h) noexcept { efpip->obj_h = std::clamp(h, 0, max_h); }
+    constexpr void set_obj_w(std::int32_t w) noexcept { efpip->obj_w = std::clamp(w, 0, max_w); }
+    constexpr void set_obj_h(std::int32_t h) noexcept { efpip->obj_h = std::clamp(h, 0, max_h); }
 
-    [[nodiscard]] static constexpr obj_filter_idx create_ofi(uint16_t object_idx, uint16_t filter_idx) noexcept;
-    [[nodiscard]] static constexpr float calc_ox(int32_t ox) noexcept;
-    [[nodiscard]] static constexpr float calc_oy(int32_t oy) noexcept;
-    [[nodiscard]] static constexpr float calc_zoom(int32_t zoom) noexcept;
-    [[nodiscard]] static constexpr float calc_cx(int32_t cx, float base_cx = 0.0f) noexcept;
-    [[nodiscard]] static constexpr float calc_cy(int32_t cy, float base_cy = 0.0f) noexcept;
-    [[nodiscard]] static float calc_rz(int32_t rz, float base_angle = 0.0f) noexcept;
+    [[nodiscard]] static constexpr ObjFilterIdx create_ofi(std::uint16_t object_idx, std::uint16_t filter_idx) noexcept;
+    [[nodiscard]] static constexpr float calc_ox(std::int32_t ox) noexcept;
+    [[nodiscard]] static constexpr float calc_oy(std::int32_t oy) noexcept;
+    [[nodiscard]] static constexpr float calc_zoom(std::int32_t zoom) noexcept;
+    [[nodiscard]] static constexpr float calc_cx(std::int32_t cx, float base_cx = 0.0f) noexcept;
+    [[nodiscard]] static constexpr float calc_cy(std::int32_t cy, float base_cy = 0.0f) noexcept;
+    [[nodiscard]] static float calc_rz(std::int32_t rz, float base_angle = 0.0f) noexcept;
 
-    [[nodiscard]] float get_cx(std::optional<int32_t> cx = std::nullopt, int32_t offset_frame = 0,
+    [[nodiscard]] float get_cx(std::optional<std::int32_t> cx = std::nullopt, std::int32_t offset_frame = 0,
                                OffsetType offset_type = OffsetType::Current) const noexcept;
-    [[nodiscard]] float get_cy(std::optional<int32_t> cy = std::nullopt, int32_t offset_frame = 0,
+    [[nodiscard]] float get_cy(std::optional<std::int32_t> cy = std::nullopt, std::int32_t offset_frame = 0,
                                OffsetType offset_type = OffsetType::Current) const noexcept;
-    [[nodiscard]] float get_rz(std::optional<int32_t> rz = std::nullopt, int32_t offset_frame = 0,
+    [[nodiscard]] float get_rz(std::optional<std::int32_t> rz = std::nullopt, std::int32_t offset_frame = 0,
                                OffsetType offset_type = OffsetType::Current) const noexcept;
-    [[nodiscard]] float calc_track_val(TrackName track_name, int32_t offset_frame = 0,
+    [[nodiscard]] float calc_track_val(TrackName track_name, std::int32_t offset_frame = 0,
                                        OffsetType offset_type = OffsetType::Current) const;
 
 private:
-    obj_filter_idx curr_ofi;
-    uint16_t curr_object_idx;
-    uint16_t curr_filter_idx;
-    int32_t local_frame;
-    int32_t max_w;
-    int32_t max_h;
+    ObjFilterIdx curr_ofi;
+    std::uint16_t curr_object_idx;
+    std::uint16_t curr_filter_idx;
+    std::int32_t local_frame;
+    std::int32_t max_w;
+    std::int32_t max_h;
 };
 
 // Functions of AviUtl Memory class.
 inline bool
-AulMemory::check_exedit_version(uintptr_t exedit_base) const noexcept {
-    int32_t version = *reinterpret_cast<int32_t *>(exedit_base + VERSION_OFFSET);
+AulMemory::check_exedit_version(std::uintptr_t exedit_base) const noexcept {
+    std::int32_t version = *reinterpret_cast<std::int32_t *>(exedit_base + Offsets::Version);
     return version == 9200;
 }
 
 inline ExEdit::Filter *
-AulMemory::get_exedit_filter_ptr(uintptr_t exedit_base) const noexcept {
-    ExEdit::Filter **efpp = reinterpret_cast<ExEdit::Filter **>(exedit_base + EFPP_OFFSET);
+AulMemory::get_exedit_filter_ptr(std::uintptr_t exedit_base) const noexcept {
+    ExEdit::Filter **efpp = reinterpret_cast<ExEdit::Filter **>(exedit_base + Offsets::ScriptEfp);
     if (efpp && *efpp)
         return *efpp;
     return nullptr;
 }
 
 inline ExEdit::FilterProcInfo *
-AulMemory::get_exedit_filter_proc_info_ptr(uintptr_t exedit_base) const noexcept {
-    ExEdit::FilterProcInfo **efpipp = reinterpret_cast<ExEdit::FilterProcInfo **>(exedit_base + EFPIPP_OFFSET);
+AulMemory::get_exedit_filter_proc_info_ptr(std::uintptr_t exedit_base) const noexcept {
+    ExEdit::FilterProcInfo **efpipp = reinterpret_cast<ExEdit::FilterProcInfo **>(exedit_base + Offsets::ScriptEfpip);
     if (efpipp && *efpipp)
         return *efpipp;
     return nullptr;
 }
 
 inline ExEdit::Filter **
-AulMemory::get_loaded_filter_table(uintptr_t exedit_base) const noexcept {
-    return reinterpret_cast<ExEdit::Filter **>(exedit_base + LOADED_FILTER_TABLE_OFFSET);
+AulMemory::get_loaded_filter_table(std::uintptr_t exedit_base) const noexcept {
+    return reinterpret_cast<ExEdit::Filter **>(exedit_base + Offsets::LoadedFilterTable);
 }
 
-inline AulMemory::get_curr_proc_fn
-AulMemory::get_get_curr_proc(uintptr_t exedit_base) const noexcept {
-    return reinterpret_cast<get_curr_proc_fn>(exedit_base + GET_CURR_PROC_OFFSET);
+inline AulMemory::GetCurrProcFn
+AulMemory::get_get_curr_proc(std::uintptr_t exedit_base) const noexcept {
+    return reinterpret_cast<GetCurrProcFn>(exedit_base + Offsets::GetCurrProc);
 }
 
-inline int32_t
-AulMemory::get_camera_mode(uintptr_t exedit_base) const noexcept {
-    return *reinterpret_cast<int32_t *>(exedit_base + CAMERA_MODE_OFFSET);
+inline std::int32_t
+AulMemory::get_camera_mode(std::uintptr_t exedit_base) const noexcept {
+    return *reinterpret_cast<std::int32_t *>(exedit_base + Offsets::CameraMode);
 }
 
-inline int32_t
-AulMemory::get_is_saving(uintptr_t exedit_base) const noexcept {
-    return *reinterpret_cast<int32_t *>(exedit_base + IS_SAVING_OFFSET);
+inline std::int32_t
+AulMemory::get_is_saving(std::uintptr_t exedit_base) const noexcept {
+    return *reinterpret_cast<std::int32_t *>(exedit_base + Offsets::IsSaving);
 }
 
 // Functions of Object Utilities class.
 // Create an object filter index from object index and filter index.
-inline constexpr ObjectUtils::obj_filter_idx
-ObjectUtils::create_ofi(uint16_t object_idx, uint16_t filter_idx) noexcept {
-    const auto filter_part = static_cast<uint32_t>(filter_idx) << 16;
-    const auto object_part = static_cast<uint32_t>(object_idx);
-    return static_cast<obj_filter_idx>(filter_part | object_part);
+inline constexpr ObjectUtils::ObjFilterIdx
+ObjectUtils::create_ofi(std::uint16_t object_idx, std::uint16_t filter_idx) noexcept {
+    const auto filter_part = static_cast<std::uint32_t>(filter_idx) << 16;
+    const auto object_part = static_cast<std::uint32_t>(object_idx);
+    return static_cast<ObjFilterIdx>(filter_part | object_part);
 }
 
 // calculate the geometry.
 // This fixed-point precision provides one more decimal digit than the trackbar,
 // ensuring accurate internal computation before mapping to UI resolution.
 inline constexpr float
-ObjectUtils::calc_ox(int32_t ox) noexcept {
+ObjectUtils::calc_ox(std::int32_t ox) noexcept {
     return static_cast<float>((static_cast<int64_t>(ox) * 100) >> 12) * 1e-2f;
 }
 
 inline constexpr float
-ObjectUtils::calc_oy(int32_t oy) noexcept {
+ObjectUtils::calc_oy(std::int32_t oy) noexcept {
     return static_cast<float>((static_cast<int64_t>(oy) * 100) >> 12) * 1e-2f;
 }
 
 inline constexpr float
-ObjectUtils::calc_zoom(int32_t zoom) noexcept {
+ObjectUtils::calc_zoom(std::int32_t zoom) noexcept {
     return static_cast<float>((static_cast<int64_t>(zoom) * 1000) >> 16) * 1e-3f;
 }
 
 inline constexpr float
-ObjectUtils::calc_cx(int32_t cx, float base_cx) noexcept {
+ObjectUtils::calc_cx(std::int32_t cx, float base_cx) noexcept {
     return base_cx + calc_oy(cx);
 }
 
 inline constexpr float
-ObjectUtils::calc_cy(int32_t cy, float base_cy) noexcept {
+ObjectUtils::calc_cy(std::int32_t cy, float base_cy) noexcept {
     return base_cy + calc_oy(cy);
 }
 
 inline float
-ObjectUtils::calc_rz(int32_t rz, float base_angle) noexcept {
+ObjectUtils::calc_rz(std::int32_t rz, float base_angle) noexcept {
     return std::fmodf(base_angle, 360.0f) + static_cast<float>((static_cast<int64_t>(rz) * 360 * 1000) >> 16) * 1e-3f;
 }
 
 inline float
-ObjectUtils::get_cx(std::optional<int32_t> cx, int32_t offset_frame, OffsetType offset_type) const noexcept {
+ObjectUtils::get_cx(std::optional<std::int32_t> cx, std::int32_t offset_frame, OffsetType offset_type) const noexcept {
     float base_cx = calc_track_val(TrackName::CenterX, offset_frame, offset_type);
     return calc_cx(cx.value_or(efpip->obj_data.cx), base_cx);
 }
 
 inline float
-ObjectUtils::get_cy(std::optional<int32_t> cy, int32_t offset_frame, OffsetType offset_type) const noexcept {
+ObjectUtils::get_cy(std::optional<std::int32_t> cy, std::int32_t offset_frame, OffsetType offset_type) const noexcept {
     float base_cy = calc_track_val(TrackName::CenterY, offset_frame, offset_type);
     return calc_cy(cy.value_or(efpip->obj_data.cy), base_cy);
 }
 
 inline float
-ObjectUtils::get_rz(std::optional<int32_t> rz, int32_t offset_frame, OffsetType offset_type) const noexcept {
+ObjectUtils::get_rz(std::optional<std::int32_t> rz, std::int32_t offset_frame, OffsetType offset_type) const noexcept {
     float base_angle = calc_track_val(TrackName::RotationZ, offset_frame, offset_type);
     return calc_rz(rz.value_or(efpip->obj_data.rz), base_angle);
 }

--- a/dll_src/aul_utils.hpp
+++ b/dll_src/aul_utils.hpp
@@ -48,14 +48,14 @@ private:
     static constexpr uintptr_t CAMERA_MODE_OFFSET = 0x013596c;
     static constexpr uintptr_t IS_SAVING_OFFSET = 0x1a52e4;
 
-    uintptr_t get_exedit_base() const;
-    bool check_exedit_version(uintptr_t exedit_base) const;
-    ExEdit::Filter *get_exedit_filter_ptr(uintptr_t exedit_base) const;
-    ExEdit::FilterProcInfo *get_exedit_filter_proc_info_ptr(uintptr_t exedit_base) const;
-    ExEdit::Filter **get_loaded_filter_table(uintptr_t exedit_base) const;
-    GetCurrentProcessing get_get_curr_proc(uintptr_t exedit_base) const;
-    int32_t get_camera_mode(uintptr_t exedit_base) const;
-    int32_t get_is_saving(uintptr_t exedit_base) const;
+    [[nodiscard]] uintptr_t get_exedit_base() const;
+    [[nodiscard]] bool check_exedit_version(uintptr_t exedit_base) const noexcept;
+    [[nodiscard]] ExEdit::Filter *get_exedit_filter_ptr(uintptr_t exedit_base) const noexcept;
+    [[nodiscard]] ExEdit::FilterProcInfo *get_exedit_filter_proc_info_ptr(uintptr_t exedit_base) const noexcept;
+    [[nodiscard]] ExEdit::Filter **get_loaded_filter_table(uintptr_t exedit_base) const noexcept;
+    [[nodiscard]] GetCurrentProcessing get_get_curr_proc(uintptr_t exedit_base) const noexcept;
+    [[nodiscard]] int32_t get_camera_mode(uintptr_t exedit_base) const noexcept;
+    [[nodiscard]] int32_t get_is_saving(uintptr_t exedit_base) const noexcept;
 };
 
 class ObjectUtils : public AulMemory {
@@ -65,40 +65,41 @@ public:
     ObjectUtils(const ObjectUtils &) = delete;
     ObjectUtils &operator=(const ObjectUtils &) = delete;
 
-    int32_t get_frame_begin() const;
-    int32_t get_frame_end() const;
-    int32_t get_frame_num() const;
-    int32_t get_local_frame() const;
-    int32_t get_obj_w() const;
-    int32_t get_obj_h() const;
-    const ExEdit::FilterProcInfo::Geometry &get_obj_data() const;
-    bool get_is_saving() const;
-    uint16_t get_curr_object_idx() const;
-    int32_t get_obj_index() const;
-    int32_t get_obj_num() const;
-    int32_t get_camera_mode() const;
-    int32_t get_max_w() const;
-    int32_t get_max_h() const;
+    [[nodiscard]] constexpr int32_t get_frame_begin() const noexcept;
+    [[nodiscard]] constexpr int32_t get_frame_end() const noexcept;
+    [[nodiscard]] constexpr int32_t get_frame_num() const noexcept;
+    [[nodiscard]] constexpr int32_t get_local_frame() const noexcept;
+    [[nodiscard]] constexpr int32_t get_obj_w() const noexcept;
+    [[nodiscard]] constexpr int32_t get_obj_h() const noexcept;
+    [[nodiscard]] constexpr const ExEdit::FilterProcInfo::Geometry &get_obj_data() const noexcept;
+    [[nodiscard]] constexpr bool get_is_saving() const noexcept;
+    [[nodiscard]] constexpr uint16_t get_curr_object_idx() const noexcept;
+    [[nodiscard]] constexpr int32_t get_obj_index() const noexcept;
+    [[nodiscard]] constexpr int32_t get_obj_num() const noexcept;
+    [[nodiscard]] constexpr int32_t get_camera_mode() const noexcept;
+    [[nodiscard]] constexpr int32_t get_max_w() const noexcept;
+    [[nodiscard]] constexpr int32_t get_max_h() const noexcept;
 
-    void set_obj_w(int32_t w);
-    void set_obj_h(int32_t h);
+    constexpr void set_obj_w(int32_t w) noexcept;
+    constexpr void set_obj_h(int32_t h) noexcept;
 
-    static constexpr ExEdit::ObjectFilterIndex create_object_filter_index(uint16_t object_index, uint16_t filter_index);
-    static constexpr float calc_ox(int32_t ox);
-    static constexpr float calc_oy(int32_t oy);
-    static constexpr float calc_zoom(int32_t zoom);
-    static constexpr float calc_cx(int32_t cx, float base_cx = 0.0f);
-    static constexpr float calc_cy(int32_t cy, float base_cy = 0.0f);
-    static float calc_rz(int32_t rz, float base_angle = 0.0f);
+    [[nodiscard]] static constexpr ExEdit::ObjectFilterIndex create_ofi(uint16_t object_idx,
+                                                                        uint16_t filter_idx) noexcept;
+    [[nodiscard]] static constexpr float calc_ox(int32_t ox) noexcept;
+    [[nodiscard]] static constexpr float calc_oy(int32_t oy) noexcept;
+    [[nodiscard]] static constexpr float calc_zoom(int32_t zoom) noexcept;
+    [[nodiscard]] static constexpr float calc_cx(int32_t cx, float base_cx = 0.0f) noexcept;
+    [[nodiscard]] static constexpr float calc_cy(int32_t cy, float base_cy = 0.0f) noexcept;
+    [[nodiscard]] static float calc_rz(int32_t rz, float base_angle = 0.0f) noexcept;
 
-    float get_cx(std::optional<int32_t> cx = std::nullopt, int32_t offset_frame = 0,
-                 OffsetType offset_type = OffsetType::Current) const;
-    float get_cy(std::optional<int32_t> cy = std::nullopt, int32_t offset_frame = 0,
-                 OffsetType offset_type = OffsetType::Current) const;
-    float get_rz(std::optional<int32_t> rz = std::nullopt, int32_t offset_frame = 0,
-                 OffsetType offset_type = OffsetType::Current) const;
-    float calc_track_val(TrackName track_name, int32_t offset_frame = 0,
-                         OffsetType offset_type = OffsetType::Current) const;
+    [[nodiscard]] float get_cx(std::optional<int32_t> cx = std::nullopt, int32_t offset_frame = 0,
+                               OffsetType offset_type = OffsetType::Current) const noexcept;
+    [[nodiscard]] float get_cy(std::optional<int32_t> cy = std::nullopt, int32_t offset_frame = 0,
+                               OffsetType offset_type = OffsetType::Current) const noexcept;
+    [[nodiscard]] float get_rz(std::optional<int32_t> rz = std::nullopt, int32_t offset_frame = 0,
+                               OffsetType offset_type = OffsetType::Current) const noexcept;
+    [[nodiscard]] float calc_track_val(TrackName track_name, int32_t offset_frame = 0,
+                                       OffsetType offset_type = OffsetType::Current) const;
 
 private:
     ExEdit::ObjectFilterIndex curr_ofi;
@@ -109,15 +110,15 @@ private:
     int32_t max_h;
 };
 
-// Functions of AviUtl Pointers class.
+// Functions of AviUtl Memory class.
 inline bool
-AulMemory::check_exedit_version(uintptr_t exedit_base) const {
+AulMemory::check_exedit_version(uintptr_t exedit_base) const noexcept {
     int32_t version = *reinterpret_cast<int32_t *>(exedit_base + VERSION_OFFSET);
     return version == 9200;
 }
 
 inline ExEdit::Filter *
-AulMemory::get_exedit_filter_ptr(uintptr_t exedit_base) const {
+AulMemory::get_exedit_filter_ptr(uintptr_t exedit_base) const noexcept {
     ExEdit::Filter **efpp = reinterpret_cast<ExEdit::Filter **>(exedit_base + EFPP_OFFSET);
     if (efpp && *efpp)
         return *efpp;
@@ -125,7 +126,7 @@ AulMemory::get_exedit_filter_ptr(uintptr_t exedit_base) const {
 }
 
 inline ExEdit::FilterProcInfo *
-AulMemory::get_exedit_filter_proc_info_ptr(uintptr_t exedit_base) const {
+AulMemory::get_exedit_filter_proc_info_ptr(uintptr_t exedit_base) const noexcept {
     ExEdit::FilterProcInfo **efpipp = reinterpret_cast<ExEdit::FilterProcInfo **>(exedit_base + EFPIPP_OFFSET);
     if (efpipp && *efpipp)
         return *efpipp;
@@ -133,104 +134,104 @@ AulMemory::get_exedit_filter_proc_info_ptr(uintptr_t exedit_base) const {
 }
 
 inline ExEdit::Filter **
-AulMemory::get_loaded_filter_table(uintptr_t exedit_base) const {
+AulMemory::get_loaded_filter_table(uintptr_t exedit_base) const noexcept {
     return reinterpret_cast<ExEdit::Filter **>(exedit_base + LOADED_FILTER_TABLE_OFFSET);
 }
 
 inline AulMemory::GetCurrentProcessing
-AulMemory::get_get_curr_proc(uintptr_t exedit_base) const {
+AulMemory::get_get_curr_proc(uintptr_t exedit_base) const noexcept {
     return reinterpret_cast<GetCurrentProcessing>(exedit_base + GET_CURR_PROC_OFFSET);
 }
 
 inline int32_t
-AulMemory::get_camera_mode(uintptr_t exedit_base) const {
+AulMemory::get_camera_mode(uintptr_t exedit_base) const noexcept {
     return *reinterpret_cast<int32_t *>(exedit_base + CAMERA_MODE_OFFSET);
 }
 
 inline int32_t
-AulMemory::get_is_saving(uintptr_t exedit_base) const {
+AulMemory::get_is_saving(uintptr_t exedit_base) const noexcept {
     return *reinterpret_cast<int32_t *>(exedit_base + IS_SAVING_OFFSET);
 }
 
-// Object Utilities Gettrers.
-inline int32_t
-ObjectUtils::get_frame_begin() const {
+// Functions of Object Utilities class.
+inline constexpr int32_t
+ObjectUtils::get_frame_begin() const noexcept {
     return efpip->objectp->frame_begin;
 }
 
-inline int32_t
-ObjectUtils::get_frame_end() const {
+inline constexpr int32_t
+ObjectUtils::get_frame_end() const noexcept {
     return efpip->objectp->frame_end;
 }
 
-inline int32_t
-ObjectUtils::get_frame_num() const {
+inline constexpr int32_t
+ObjectUtils::get_frame_num() const noexcept {
     return efpip->frame_num;
 }
 
-inline int32_t
-ObjectUtils::get_local_frame() const {
+inline constexpr int32_t
+ObjectUtils::get_local_frame() const noexcept {
     return local_frame;
 }
 
-inline int32_t
-ObjectUtils::get_obj_w() const {
+inline constexpr int32_t
+ObjectUtils::get_obj_w() const noexcept {
     return efpip->obj_w;
 }
 
-inline int32_t
-ObjectUtils::get_obj_h() const {
+inline constexpr int32_t
+ObjectUtils::get_obj_h() const noexcept {
     return efpip->obj_h;
 }
 
-inline const ExEdit::FilterProcInfo::Geometry &
-ObjectUtils::get_obj_data() const {
+inline constexpr const ExEdit::FilterProcInfo::Geometry &
+ObjectUtils::get_obj_data() const noexcept {
     return efpip->obj_data;
 }
 
-inline bool
-ObjectUtils::get_is_saving() const {
+inline constexpr bool
+ObjectUtils::get_is_saving() const noexcept {
     return is_saving;
 }
 
-inline uint16_t
-ObjectUtils::get_curr_object_idx() const {
+inline constexpr uint16_t
+ObjectUtils::get_curr_object_idx() const noexcept {
     return curr_object_idx;
 }
 
-inline int32_t
-ObjectUtils::get_obj_index() const {
+inline constexpr int32_t
+ObjectUtils::get_obj_index() const noexcept {
     return efpip->obj_index;
 }
 
-inline int32_t
-ObjectUtils::get_obj_num() const {
+inline constexpr int32_t
+ObjectUtils::get_obj_num() const noexcept {
     return efpip->obj_num;
 }
 
-inline int32_t
-ObjectUtils::get_camera_mode() const {
+inline constexpr int32_t
+ObjectUtils::get_camera_mode() const noexcept {
     return camera_mode;
 }
 
-inline int32_t
-ObjectUtils::get_max_w() const {
+inline constexpr int32_t
+ObjectUtils::get_max_w() const noexcept {
     return max_w;
 }
 
-inline int32_t
-ObjectUtils::get_max_h() const {
+inline constexpr int32_t
+ObjectUtils::get_max_h() const noexcept {
     return max_h;
 }
 
 // Object Utilities Setters.
-inline void
-ObjectUtils::set_obj_w(int32_t w) {
+inline constexpr void
+ObjectUtils::set_obj_w(int32_t w) noexcept {
     efpip->obj_w = std::clamp(w, 0, max_w);
 }
 
-inline void
-ObjectUtils::set_obj_h(int32_t h) {
+inline constexpr void
+ObjectUtils::set_obj_h(int32_t h) noexcept {
     efpip->obj_h = std::clamp(h, 0, max_h);
 }
 
@@ -238,56 +239,57 @@ ObjectUtils::set_obj_h(int32_t h) {
 // This fixed-point precision provides one more decimal digit than the trackbar,
 // ensuring accurate internal computation before mapping to UI resolution.
 inline constexpr float
-ObjectUtils::calc_ox(int32_t ox) {
+ObjectUtils::calc_ox(int32_t ox) noexcept {
     return static_cast<float>((static_cast<int64_t>(ox) * 100) >> 12) * 1e-2f;
 }
 
 inline constexpr float
-ObjectUtils::calc_oy(int32_t oy) {
+ObjectUtils::calc_oy(int32_t oy) noexcept {
     return static_cast<float>((static_cast<int64_t>(oy) * 100) >> 12) * 1e-2f;
 }
 
 inline constexpr float
-ObjectUtils::calc_zoom(int32_t zoom) {
+ObjectUtils::calc_zoom(int32_t zoom) noexcept {
     return static_cast<float>((static_cast<int64_t>(zoom) * 1000) >> 16) * 1e-3f;
 }
 
 inline constexpr float
-ObjectUtils::calc_cx(int32_t cx, float base_cx) {
+ObjectUtils::calc_cx(int32_t cx, float base_cx) noexcept {
     return base_cx + calc_oy(cx);
 }
 
 inline constexpr float
-ObjectUtils::calc_cy(int32_t cy, float base_cy) {
+ObjectUtils::calc_cy(int32_t cy, float base_cy) noexcept {
     return base_cy + calc_oy(cy);
 }
 
 inline float
-ObjectUtils::calc_rz(int32_t rz, float base_angle) {
+ObjectUtils::calc_rz(int32_t rz, float base_angle) noexcept {
     return std::fmod(base_angle, 360.0f) + static_cast<float>((static_cast<int64_t>(rz) * 360 * 1000) >> 16) * 1e-3f;
 }
 
 inline float
-ObjectUtils::get_cx(std::optional<int32_t> cx, int32_t offset_frame, OffsetType offset_type) const {
+ObjectUtils::get_cx(std::optional<int32_t> cx, int32_t offset_frame, OffsetType offset_type) const noexcept {
     float base_cx = calc_track_val(TrackName::CenterX, offset_frame, offset_type);
     return calc_cx(cx.value_or(efpip->obj_data.cx), base_cx);
 }
 
 inline float
-ObjectUtils::get_cy(std::optional<int32_t> cy, int32_t offset_frame, OffsetType offset_type) const {
+ObjectUtils::get_cy(std::optional<int32_t> cy, int32_t offset_frame, OffsetType offset_type) const noexcept {
     float base_cy = calc_track_val(TrackName::CenterY, offset_frame, offset_type);
     return calc_cy(cy.value_or(efpip->obj_data.cy), base_cy);
 }
 
 inline float
-ObjectUtils::get_rz(std::optional<int32_t> rz, int32_t offset_frame, OffsetType offset_type) const {
+ObjectUtils::get_rz(std::optional<int32_t> rz, int32_t offset_frame, OffsetType offset_type) const noexcept {
     float base_angle = calc_track_val(TrackName::RotationZ, offset_frame, offset_type);
     return calc_rz(rz.value_or(efpip->obj_data.rz), base_angle);
 }
 
 // Create an object filter index from object index and filter index.
 inline constexpr ExEdit::ObjectFilterIndex
-ObjectUtils::create_object_filter_index(uint16_t object_index, uint16_t filter_index) {
-    return static_cast<ExEdit::ObjectFilterIndex>((static_cast<uint32_t>(filter_index) << 16)
-                                                  | static_cast<uint32_t>(object_index));
+ObjectUtils::create_ofi(uint16_t object_idx, uint16_t filter_idx) noexcept {
+    const auto filter_part = static_cast<std::uint32_t>(filter_idx) << 16;
+    const auto object_part = static_cast<std::uint32_t>(object_idx);
+    return static_cast<ExEdit::ObjectFilterIndex>(filter_part | object_part);
 }

--- a/dll_src/lua_func.cpp
+++ b/dll_src/lua_func.cpp
@@ -89,9 +89,9 @@ GLShaderKit::setPlaneVertex(int n) const {
 }
 
 void
-GLShaderKit::setShader(const std::string &shader_path, bool force_reload) const {
+GLShaderKit::setShader(const char *shader_path, bool force_reload) const {
     lua_getfield(L, -1, "setShader");
-    lua_pushstring(L, shader_path.c_str());
+    lua_pushstring(L, shader_path);
     lua_pushboolean(L, force_reload);
     lua_call(L, 2, 0);
 }
@@ -107,27 +107,27 @@ GLShaderKit::setTexture2D(int unit, const Image &img) const {
 }
 
 void
-GLShaderKit::setFloat(std::string name, const std::vector<float> &vec) const {
+GLShaderKit::setFloat(const char *name, const std::vector<float> &vec) const {
     lua_getfield(L, -1, "setFloat");
-    lua_pushstring(L, name.c_str());
+    lua_pushstring(L, name);
     for (float value : vec) lua_pushnumber(L, value);
 
     lua_call(L, vec.size() + 1, 0);
 }
 
 void
-GLShaderKit::setInt(std::string name, const std::vector<int> &vec) const {
+GLShaderKit::setInt(const char *name, const std::vector<int> &vec) const {
     lua_getfield(L, -1, "setInt");
-    lua_pushstring(L, name.c_str());
+    lua_pushstring(L, name);
     for (int value : vec) lua_pushinteger(L, value);
 
     lua_call(L, vec.size() + 1, 0);
 }
 
 void
-GLShaderKit::setMatrix(std::string name, std::string type, bool transpose, float angle_rad) const {
+GLShaderKit::setMatrix(const char *name, std::string type, bool transpose, float angle_rad) const {
     lua_getfield(L, -1, "setMatrix");
-    lua_pushstring(L, name.c_str());
+    lua_pushstring(L, name);
     lua_pushstring(L, type.c_str());
     lua_pushboolean(L, transpose);
 
@@ -148,7 +148,8 @@ GLShaderKit::setMatrix(std::string name, std::string type, bool transpose, float
     lua_call(L, 4, 0);
 }
 
-void GLShaderKit::setMat3(const char *name, bool transpose, const Mat3<float> &mat3) const {
+void
+GLShaderKit::setMat3(const char *name, bool transpose, const Mat3<float> &mat3) const {
     lua_getfield(L, -1, "setMatrix");
     lua_pushstring(L, name);
     lua_pushstring(L, "3x3");
@@ -179,9 +180,9 @@ void GLShaderKit::setMat3(const char *name, bool transpose, const Mat3<float> &m
 }
 
 void
-GLShaderKit::draw(std::string mode, Image &img) const {
+GLShaderKit::draw(const char *mode, Image &img) const {
     lua_getfield(L, -1, "draw");
-    lua_pushstring(L, mode.c_str());
+    lua_pushstring(L, mode);
     lua_pushlightuserdata(L, img.data);
     lua_pushinteger(L, img.size.get_x());
     lua_pushinteger(L, img.size.get_y());

--- a/dll_src/lua_func.cpp
+++ b/dll_src/lua_func.cpp
@@ -190,18 +190,7 @@ GLShaderKit::draw(const char *mode, Image &img) const {
 }
 
 void
-GLShaderKit::setParamsForOMBStep(const std::string &name, const Steps &steps) const {
-    std::string pos_param = "step_pos_" + name;
-    std::string scale_param = "step_scale_" + name;
-    std::string rot_param = "step_rot_mat_" + name;
-
-    setFloat(pos_param.c_str(), {steps.location.get_x(), steps.location.get_y()});
-    setFloat(scale_param.c_str(), {steps.scale});
-    setMatrix(rot_param.c_str(), "2x2", false, steps.rz_rad);
-}
-
-void
-expand_image(const std::array<int, 4> &expansion, lua_State *L) {
+lua_func::expand_image(const std::array<int, 4> &expansion, lua_State *L) {
     lua_getglobal(L, "obj");
     lua_getfield(L, -1, "effect");
     lua_pushstring(L, "領域拡張");

--- a/dll_src/lua_func.cpp
+++ b/dll_src/lua_func.cpp
@@ -148,6 +148,36 @@ GLShaderKit::setMatrix(std::string name, std::string type, bool transpose, float
     lua_call(L, 4, 0);
 }
 
+void GLShaderKit::setMat3(const char *name, bool transpose, const Mat3<float> &mat3) const {
+    lua_getfield(L, -1, "setMatrix");
+    lua_pushstring(L, name);
+    lua_pushstring(L, "3x3");
+    lua_pushboolean(L, transpose);
+
+    lua_newtable(L);
+
+    lua_pushnumber(L, mat3(0, 0));
+    lua_rawseti(L, -2, 1);
+    lua_pushnumber(L, mat3(0, 1));
+    lua_rawseti(L, -2, 2);
+    lua_pushnumber(L, mat3(0, 2));
+    lua_rawseti(L, -2, 3);
+    lua_pushnumber(L, mat3(1, 0));
+    lua_rawseti(L, -2, 4);
+    lua_pushnumber(L, mat3(1, 1));
+    lua_rawseti(L, -2, 5);
+    lua_pushnumber(L, mat3(1, 2));
+    lua_rawseti(L, -2, 6);
+    lua_pushnumber(L, mat3(2, 0));
+    lua_rawseti(L, -2, 7);
+    lua_pushnumber(L, mat3(2, 1));
+    lua_rawseti(L, -2, 8);
+    lua_pushnumber(L, mat3(2, 2));
+    lua_rawseti(L, -2, 9);
+
+    lua_call(L, 4, 0);
+}
+
 void
 GLShaderKit::draw(std::string mode, Image &img) const {
     lua_getfield(L, -1, "draw");

--- a/dll_src/lua_func.hpp
+++ b/dll_src/lua_func.hpp
@@ -42,13 +42,13 @@ public:
     bool activate() const;
     void deactivate() const;
     void setPlaneVertex(int n) const;
-    void setShader(const std::string &shader_path, bool force_reload) const;
+    void setShader(const char *shader_path, bool force_reload) const;
     void setTexture2D(int unit, const Image &img) const;
-    void setFloat(std::string name, const std::vector<float> &vec) const;
-    void setInt(std::string name, const std::vector<int> &vec) const;
-    void setMatrix(std::string name, std::string type, bool transpose, float angle_rad) const;
+    void setFloat(const char* name, const std::vector<float> &vec) const;
+    void setInt(const char* name, const std::vector<int> &vec) const;
+    void setMatrix(const char* name, std::string type, bool transpose, float angle_rad) const;
     void setMat3(const char *name, bool transpose, const Mat3<float> &mat3) const;
-    void draw(std::string mode, Image &img) const;
+    void draw(const char* mode, Image &img) const;
 
     void setParamsForOMBStep(const std::string &name, const Steps &steps) const;  // OMBStep: Object Motion Blur Step
 

--- a/dll_src/lua_func.hpp
+++ b/dll_src/lua_func.hpp
@@ -10,6 +10,7 @@
 
 #include "structs.hpp"
 #include "vector_2d.hpp"
+#include "vector_3d.hpp"
 
 struct ObjectMotionBlurParams {
     const float shutter_angle;
@@ -46,6 +47,7 @@ public:
     void setFloat(std::string name, const std::vector<float> &vec) const;
     void setInt(std::string name, const std::vector<int> &vec) const;
     void setMatrix(std::string name, std::string type, bool transpose, float angle_rad) const;
+    void setMat3(const char *name, bool transpose, const Mat3<float> &mat3) const;
     void draw(std::string mode, Image &img) const;
 
     void setParamsForOMBStep(const std::string &name, const Steps &steps) const;  // OMBStep: Object Motion Blur Step

--- a/dll_src/lua_func.hpp
+++ b/dll_src/lua_func.hpp
@@ -44,17 +44,17 @@ public:
     void setPlaneVertex(int n) const;
     void setShader(const char *shader_path, bool force_reload) const;
     void setTexture2D(int unit, const Image &img) const;
-    void setFloat(const char* name, const std::vector<float> &vec) const;
-    void setInt(const char* name, const std::vector<int> &vec) const;
-    void setMatrix(const char* name, std::string type, bool transpose, float angle_rad) const;
+    void setFloat(const char *name, const std::vector<float> &vec) const;
+    void setInt(const char *name, const std::vector<int> &vec) const;
+    void setMatrix(const char *name, std::string type, bool transpose, float angle_rad) const;
     void setMat3(const char *name, bool transpose, const Mat3<float> &mat3) const;
-    void draw(const char* mode, Image &img) const;
-
-    void setParamsForOMBStep(const std::string &name, const Steps &steps) const;  // OMBStep: Object Motion Blur Step
+    void draw(const char *mode, Image &img) const;
 
 private:
     lua_State *L;
 };
 
+namespace lua_func {
 void
 expand_image(const std::array<int, 4> &expansion, lua_State *L);
+}  // namespace lua_func

--- a/dll_src/object_motion_blur.cpp
+++ b/dll_src/object_motion_blur.cpp
@@ -4,12 +4,8 @@
 #include <filesystem>
 #include <iostream>
 #include <memory>
-#include <optional>
-#include <sstream>
 #include <stdexcept>
 #include <string>
-#include <type_traits>
-#include <variant>
 #define NOMINMAX
 #include <Windows.h>
 
@@ -53,7 +49,7 @@ apply_geo(Transform &tf, std::uint32_t shared_mem_key, std::uint32_t slot_id, co
 }
 
 // Calculate the transform before frame 0.
-inline static std::variant<Transform, std::array<Transform, 2>>
+inline static std::array<Transform, 2>
 calc_neg_frame(const std::array<Transform, 3> &tf_array, bool will_calc_2f = false) {
     Transform d1 = tf_array[1] - tf_array[0];
     Transform d2 = tf_array[2] - tf_array[1];
@@ -61,14 +57,14 @@ calc_neg_frame(const std::array<Transform, 3> &tf_array, bool will_calc_2f = fal
 
     // Uniformly accelerated linear motion
     if (will_calc_2f) {
-        return std::array<Transform, 2>{tf_neg_1f, tf_neg_1f - d1 * 3.0f + d2 * 2.0f};
+        return {tf_neg_1f, tf_neg_1f - d1 * 3.0f + d2 * 2.0f};
     } else {
-        return tf_neg_1f;
+        return {tf_neg_1f, Transform()};
     }
 }
 
 // Calculate the amounticient that determines the length of the blur.
-inline static SegData<float>
+inline static constexpr SegData<float>
 calc_blur_amt(float shutter_angle) {
     constexpr float inv_360 = 1.0f / 360.0f;
 
@@ -76,48 +72,25 @@ calc_blur_amt(float shutter_angle) {
     const float seg1 = std::min(ratio, 1.0f);
     const float seg2 = std::max(ratio - 1.0f, 0.0f);
 
-    return SegData<float>(seg1, seg2);
+    return {seg1, seg2};
 }
 
 // Calculate the amounticient that determines the offset movement amount.
-static std::array<float, 3>
-calc_offset_amt(const SegmentData<Displacements> &disp_data, float shutter_angle, float shutter_phase) {
-    constexpr float inv_360 = 1.0f / 360.0f;
-    constexpr float inv_720 = 1.0f / 720.0f;
-
-    if (!disp_data.seg1 || !disp_data.seg1->get_is_moved()) {
-        return {0.0f, 0.0f, 0.0f};
-    } else if (!disp_data.seg2) {
-        float amt = (shutter_angle + shutter_phase) * inv_360;
-        return {amt, amt, amt};
-    } else if (disp_data.seg2->get_is_moved()) {
-        auto [distance, zoom, rz_deg] = disp_data.seg2->calc_relative_displacements(disp_data.seg1.value());
-        float factor = (shutter_angle + shutter_phase) * inv_720;
-        auto calc = [&](float ratio) -> float {
-            return (3.0f - ratio + (ratio - 1.0f) * shutter_angle * inv_360) * factor;
-        };
-        return {calc(distance), calc(zoom), calc(rz_deg)};
-    } else {
-        float amt = 1.0f + shutter_phase * inv_360;
-        return {amt, amt, amt};
-    }
-}
-
-inline static SegData<float>
+inline static constexpr SegData<float>
 calc_offset_amt(float shutter_angle, float shutter_phase) {
     float amt = (shutter_angle + shutter_phase) / -360.0f;
     if (shutter_angle <= 360.0f) {
-        return SegData<float>(amt, 0.0f);
+        return {amt, 0.0f};
     } else {
         float amt_seg1 = std::max(amt, -1.0f);
         float amt_seg2 = std::min(amt + 1.0f, 0.0f);
-        return SegData<float>(amt_seg1, amt_seg2);
+        return {amt_seg1, amt_seg2};
     }
 }
 
 // Calculate the actual number of samples to be used.
-inline static SegData<int>
-calc_samp(const SegData<int> &req_samp_data, int samp_lim, int total_req_samp) {
+inline static constexpr SegData<int>
+calc_samp(const OptSegData<int> &req_samp_data, int samp_lim, int total_req_samp) {
     if (!req_samp_data.seg2) {
         int samp = std::min(*req_samp_data.seg1, samp_lim);
         return SegData<int>(samp, 0);
@@ -125,155 +98,77 @@ calc_samp(const SegData<int> &req_samp_data, int samp_lim, int total_req_samp) {
 
     int samp_seg1 = (samp_lim * *req_samp_data.seg1) / total_req_samp;
     int samp_seg2 = samp_lim - samp_seg1;
-    return SegData<int>(samp_seg1, samp_seg2);
+    return {samp_seg1, samp_seg2};
 }
 
-inline static Corner
-calc_corners(const Vec2<float> &base, const Vec2<float> &disp, const Vec2<float> &bbox_size, float offset_scale,
-             const Vec2<int> &img_size) {
-    Corner corner;
-    corner.location = base + disp * offset_scale;
-    Vec2<float> diff_half_size = (bbox_size * offset_scale - static_cast<Vec2<float>>(img_size)) * 0.5f;
-    corner.upper_left = static_cast<Vec2<int>>((diff_half_size - corner.location).ceil());
-    corner.lower_right = static_cast<Vec2<int>>((diff_half_size + corner.location).ceil());
-    return corner;
-}
-
-// Resize the image.
-static void
-resize_image(const Vec2<int> &img_size, const Vec2<float> &center, const SegmentData<Displacements> &disp,
-             const SegData<float> &blur, const Steps &offset, float scale_factor_seg1, const Vec2<int> &max_size,
-             lua_State *L) {
-    if (!disp.seg1 || !blur.seg1) {
-        return;
-    }
-
-    float offset_scale_inv = 1.0f / offset.scale;
-    std::array<Corner, 3> corners;
-    int count = 2;
-
-    // Displacement.
-    Vec2<float> d0 = center.rotate(-offset.rz_rad, -1.0f) - offset.location;
-    Vec2<float> d1 = disp.seg1->calc_relative_location(*blur.seg1, offset.rz_rad);
-
-    // Bounding box size.
-    Vec2<float> curr_f_size = disp.seg1->calc_bounding_box_size(img_size, 0.0f, offset.rz_rad);
-    Vec2<float> prev_1f_size = disp.seg1->calc_bounding_box_size(img_size, *blur.seg1, offset.rz_rad);
-
-    corners[0] = calc_corners(center, d0, curr_f_size, offset_scale_inv, img_size);
-    corners[1] = calc_corners(corners[0].location, d1, prev_1f_size, offset_scale_inv, img_size);
-
-    // If the second segment is available, calculate the corners for it.
-    if (disp.seg2 && blur.seg2) {
-        Vec2<float> d2 = disp.seg2->calc_relative_location(*blur.seg2, offset.rz_rad)
-                                 .rotate(disp.seg1->get_rz(), scale_factor_seg1);
-        Vec2<float> prev_2f_size =
-                disp.seg2->calc_bounding_box_size(img_size, *blur.seg2, offset.rz_rad - disp.seg1->get_rz())
-                * scale_factor_seg1;
-
-        corners[2] = calc_corners(corners[1].location, d2, prev_2f_size, offset_scale_inv, img_size);
-        count++;
-    }
-
+static inline Vec2<int>
+expand_img(lua_State *L, bool can_render_2f, const Vec2<float> &img_size, const std::array<Vec2<float>, 3> &pos_data,
+           const std::array<Vec2<float>, 3> &bbox_data) {
     std::array<int, 4> expansion = {0, 0, 0, 0};  // top, bottom, left, right
+    int max_idx = can_render_2f ? 2 : 1;
 
-    for (int i = 0; i < count; i++) {
-        expansion[0] = std::max(expansion[0], corners[i].upper_left.get_y());
-        expansion[1] = std::max(expansion[1], corners[i].lower_right.get_y());
-        expansion[2] = std::max(expansion[2], corners[i].upper_left.get_x());
-        expansion[3] = std::max(expansion[3], corners[i].lower_right.get_x());
+    for (int i = 0; i <= max_idx; ++i) {
+        Vec2<float> diff_half_size = (bbox_data[i] - img_size) * 0.5f;
+        Vec2<int> upper_left = static_cast<Vec2<int>>((diff_half_size - pos_data[i]).ceil());
+        Vec2<int> lower_right = static_cast<Vec2<int>>((diff_half_size + pos_data[i]).ceil());
+
+        expansion[0] = std::max(expansion[0], upper_left.get_y());
+        expansion[1] = std::max(expansion[1], lower_right.get_y());
+        expansion[2] = std::max(expansion[2], upper_left.get_x());
+        expansion[3] = std::max(expansion[3], lower_right.get_x());
     }
 
-    Vec2<int> new_size = img_size + Vec2<int>(expansion[2] + expansion[3], expansion[0] + expansion[1]);
-    if (new_size.get_x() > max_size.get_x() || new_size.get_y() > max_size.get_y()) {
-        std::cout << WARNING_COL << "[ObjectMotionBlur][WARNING] Image size exceeds maximum size.\n"
-                  << "New size: " << new_size << "\nMax size:" << max_size << RESET_COL << std::endl;
-    }
+    lua_func::expand_image(expansion, L);
 
-    expand_image(expansion, L);
+    return static_cast<Vec2<int>>(img_size) + Vec2<int>(expansion[2] + expansion[3], expansion[0] + expansion[1]);
 }
 
 static void
-resize_img(lua_State *L, const SegData<Delta> &delta_data, const SegData<float> &offset_amt_data,
+resize_img(lua_State *L, bool can_render_2f, OptSegData<Delta> &delta_data, const SegData<float> &offset_amt_data,
            const SegData<float> &blur_amt_data, const Vec2<float> &center, const Vec2<float> &img_size,
            const Vec2<int> &max_size) {
     MappingData<Mat3<float>> htm_data;
-    MappingData<Vec3<float>> pos_data;
+    std::array<Vec2<float>, 3> pos_data{}, bbox_data{};
 
-    // Calculate the offset HTM (Homogeneous Transformation Matrix).
-    auto offset_mapping = Delta::calc_offset_mapping(delta_data, offset_amt_data);
-    htm_data.offset = offset_mapping.htm;
+    // Calculate the HTMs(Homogeneous Transformation Matrix).
+    htm_data.offset = Delta::calc_offset_htm(delta_data, offset_amt_data);
 
-    // Calculate the HTM.
-    htm_data.seg1 = delta_data.seg1->calc_htm(*blur_amt_data.seg1);
-    (*htm_data.seg1)[2] = offset_mapping.adj_mat * (*htm_data.seg1)[2];
+    htm_data.seg1 = delta_data.seg1->calc_htm(blur_amt_data.seg1);
 
-    if (delta_data.seg2) {
-        htm_data.seg2 = delta_data.seg2->calc_htm(*blur_amt_data.seg2);
-        (*htm_data.seg2)[2] = offset_mapping.adj_mat * (*htm_data.seg2)[2];
-    }
+    if (delta_data.seg2)
+        htm_data.seg2 = delta_data.seg2->calc_htm(blur_amt_data.seg2);
 
     // Forward Kinematics.
-    Vec3<float> pivot(center, 1.0f);
     Vec3<float> center_curr_f(-center, 1.0f);
     auto htm = *htm_data.offset;
-    pos_data.offset = (htm * center_curr_f) + pivot;
+    pos_data[0] = (htm * center_curr_f).to_vec2() + center;
+    bbox_data[0] = (htm.to_mat2().abs()) * img_size;
 
     auto center_prev_1f = Vec3<float>(delta_data.seg1->get_center(), 1.0f);
     htm = htm * *htm_data.seg1;
-    pos_data.seg1 = (htm * center_prev_1f) + pivot;
+    pos_data[1] = (htm * center_prev_1f).to_vec2() + center;
+    bbox_data[1] = (htm.to_mat2().abs()) * img_size;
 
     if (delta_data.seg2) {
         auto center_prev_2f = Vec3<float>(delta_data.seg2->get_center(), 1.0f);
         htm = htm * *htm_data.seg2;
-        pos_data.seg2 = (htm * center_prev_2f) + pivot;
+        pos_data[2] = (htm * center_prev_2f).to_vec2() + center;
+        bbox_data[2] = (htm.to_mat2().abs()) * img_size;
     }
 
-    lua_getglobal(L, "obj");
-    lua_getfield(L, -1, "effect");
-    lua_pushstring(L, "マスク");
-    lua_pushstring(L, "X");
-    lua_pushnumber(L, pos_data.offset->get_x());
-    lua_pushstring(L, "Y");
-    lua_pushnumber(L, pos_data.offset->get_y());
-    lua_pushstring(L, "サイズ");
-    lua_pushnumber(L, 50);
-    lua_pushstring(L, "マスクの反転");
-    lua_pushnumber(L, 1);
-    lua_call(L, 9, 0);
+    // Expand image size.
+    auto new_size = expand_img(L, can_render_2f, img_size, pos_data, bbox_data);
 
-    lua_getfield(L, -1, "effect");
-    lua_pushstring(L, "マスク");
-    lua_pushstring(L, "X");
-    lua_pushnumber(L, pos_data.seg1->get_x());
-    lua_pushstring(L, "Y");
-    lua_pushnumber(L, pos_data.seg1->get_y());
-    lua_pushstring(L, "サイズ");
-    lua_pushnumber(L, 50);
-    lua_pushstring(L, "マスクの反転");
-    lua_pushnumber(L, 1);
-    lua_call(L, 9, 0);
-
-    if (delta_data.seg2) {
-        lua_getfield(L, -1, "effect");
-        lua_pushstring(L, "マスク");
-        lua_pushstring(L, "X");
-        lua_pushnumber(L, pos_data.seg2->get_x());
-        lua_pushstring(L, "Y");
-        lua_pushnumber(L, pos_data.seg2->get_y());
-        lua_pushstring(L, "サイズ");
-        lua_pushnumber(L, 50);
-        lua_pushstring(L, "マスクの反転");
-        lua_pushnumber(L, 1);
-        lua_call(L, 9, 0);
-    }
-    lua_pop(L, 1);
+    // Warning.
+    if (new_size.get_x() > max_size.get_x() || new_size.get_y() > max_size.get_y())
+        std::cout << WARNING_COL << "[ObjectMotionBlur][WARNING] Image size exceeds maximum size.\n"
+                  << "New size: " << new_size << "\nMax size:" << max_size << RESET_COL << std::endl;
 }
 
 // Rendering.
 static void
-render_object_motion_blur(lua_State *L, const ObjectMotionBlurParams &params, const SegData<int> &samp_data,
-                          const MappingData<Mat3<float>> &htm_data) {
+render_object_motion_blur(lua_State *L, bool can_render_2f, const ObjectMotionBlurParams &params,
+                          const SegData<int> &samp_data, const MappingData<Mat3<float>> &htm_data) {
     namespace fs = std::filesystem;
 
     fs::path shader_path = get_self_dir() / params.shader_dir.relative_path() / "MotionBlur_K.frag";
@@ -285,23 +180,25 @@ render_object_motion_blur(lua_State *L, const ObjectMotionBlurParams &params, co
         throw std::runtime_error("GL Shader Kit is not available.");
 
     Image img = gl_shader_kit.get_image();
+    Vec2<float> res = static_cast<Vec2<float>>(img.size);
+    Vec2<float> pivot = img.center + res * 0.5f;
 
     gl_shader_kit.activate();
     gl_shader_kit.setPlaneVertex(1);
     gl_shader_kit.setShader(shader_path.string().c_str(), params.reload_shader);
 
     gl_shader_kit.setTexture2D(0, img);
-    Vec2<float> res = static_cast<Vec2<float>>(img.size);
-    Vec2<float> pivot = img.center + res * 0.5f;
     gl_shader_kit.setFloat("res", {res.get_x(), res.get_y()});
     gl_shader_kit.setFloat("pivot", {pivot.get_x(), pivot.get_y()});
     gl_shader_kit.setInt("mix_orig_img", {params.mix_orig_img});
-    gl_shader_kit.setInt("samp", {*samp_data.seg1, *samp_data.seg2});
+    gl_shader_kit.setInt("samp", {samp_data.seg1, samp_data.seg2});
 
     gl_shader_kit.setMat3("htm_offset", false, *htm_data.offset);
     gl_shader_kit.setMat3("init_htm_seg1", false, *htm_data.seg1);
-    if (htm_data.seg2)
+    if (can_render_2f)
         gl_shader_kit.setMat3("init_htm_seg2", false, *htm_data.seg2);
+    else
+        gl_shader_kit.setMat3("init_htm_seg2", false, Mat3<float>::identity());
 
     gl_shader_kit.draw("TRIANGLE_STRIP", img);
     gl_shader_kit.deactivate();
@@ -412,10 +309,8 @@ process_object_motion_blur(lua_State *L) {
         // Prepare the items needed for calculation.
         bool should_calc_prev_2f = params.shutter_angle > 360.0f && (params.calc_neg_f || local_frame >= 2);
 
-        SegmentData<Displacements> disp_data;
-        SegmentData<Steps> steps_data;
-        SegData<Delta> delta_data;
-        SegData<int> req_samp_data;
+        OptSegData<Delta> delta_data;
+        OptSegData<int> req_samp_data;
         MappingData<Mat3<float>> htm_data;
 
         Vec2<float> img_size = static_cast<Vec2<float>>(Vec2<int>(obj_utils.get_obj_w(), obj_utils.get_obj_h()));
@@ -437,60 +332,34 @@ process_object_motion_blur(lua_State *L) {
             // Calculate displacements from transforms.
             // Calculate frames that do not actually exist.
             if (local_frame == 0) {
-                auto tf_neg_f = calc_neg_frame(tf_array, should_calc_prev_2f);
-                std::visit(
-                        [&](auto &&tf) {
-                            if constexpr (std::is_same_v<std::decay_t<decltype(tf)>, Transform>) {
-                                disp_data.seg1 = Displacements(tf_array[0], tf);
-                                delta_data.seg1 = Delta(tf_array[0], tf);
-                            } else {
-                                auto &[neg_1f, neg_2f] = tf;
-                                disp_data.seg1 = Displacements(tf_array[0], neg_1f);
-                                disp_data.seg2 = Displacements(neg_1f, neg_2f);
-                                delta_data.seg1 = Delta(tf_array[0], neg_1f);
-                                delta_data.seg2 = Delta(neg_1f, neg_2f);
-                            }
-                        },
-                        tf_neg_f);
+                auto [tf_neg_1f, tf_neg_2f] = calc_neg_frame(tf_array, should_calc_prev_2f);
+
+                delta_data.seg1 = Delta(tf_array[0], tf_neg_1f);
+                if (should_calc_prev_2f)
+                    delta_data.seg2 = Delta(tf_neg_1f, tf_neg_2f);
+
             } else {
-                if (!should_calc_prev_2f) {
-                    disp_data.seg1 = Displacements(tf_array[1], tf_array[0]);
-                    delta_data.seg1 = Delta(tf_array[1], tf_array[0]);
-                } else {
-                    auto tf_neg_f = calc_neg_frame(tf_array);
-                    std::visit(
-                            [&](auto &&tf) {
-                                if constexpr (std::is_same_v<std::decay_t<decltype(tf)>, Transform>) {
-                                    disp_data.seg1 = Displacements(tf_array[1], tf_array[0]);
-                                    disp_data.seg2 = Displacements(tf_array[0], tf);
-                                    delta_data.seg1 = Delta(tf_array[1], tf_array[0]);
-                                    delta_data.seg2 = Delta(tf_array[0], tf);
-                                } else {
-                                    throw std::runtime_error("Unexpected variant type in tf_neg_f.");
-                                }
-                            },
-                            tf_neg_f);
+                delta_data.seg1 = Delta(tf_array[1], tf_array[0]);
+                if (should_calc_prev_2f) {
+                    auto [tf_neg_1f, _] = calc_neg_frame(tf_array);
+                    delta_data.seg2 = Delta(tf_array[0], tf_neg_1f);
                 }
             }
         } else if (local_frame != 0) {  // Default case.
             Transform tf_curr_f = Transform(obj_utils);
             Transform tf_prev_1f = Transform(obj_utils, -1);
-
             if (params.use_geo) {
                 tf_curr_f.apply_geometry(geo_curr_f);
                 apply_geo(tf_prev_1f, shared_mem_key, base_slot_id, geo_curr_f);
             }
 
-            disp_data.seg1 = Displacements(tf_curr_f, tf_prev_1f);
             delta_data.seg1 = Delta(tf_curr_f, tf_prev_1f);
 
             if (should_calc_prev_2f) {
                 Transform tf_prev_2f = Transform(obj_utils, -2);
-
                 if (params.use_geo)
                     apply_geo(tf_prev_2f, shared_mem_key, base_slot_id - 1u, geo_curr_f);
 
-                disp_data.seg2 = Displacements(tf_prev_1f, tf_prev_2f);
                 delta_data.seg2 = Delta(tf_prev_1f, tf_prev_2f);
             }
         }
@@ -502,18 +371,20 @@ process_object_motion_blur(lua_State *L) {
         if (!delta_data.seg1)
             return 0;
 
-        bool can_render_prev_2f = delta_data.seg2 && delta_data.seg2->get_is_moved();  // Render to 2 frames ago.
+        // Flag (Render to 2 frames ago).
+        bool can_render_2f = delta_data.seg2 && delta_data.seg2->get_is_moved();
 
         // Calculate the blur amounts.
         SegData<float> blur_amt_data = calc_blur_amt(params.shutter_angle);
+        SegData<float> offset_amt_data = calc_offset_amt(params.shutter_angle, params.shutter_phase);
 
         // Calculate the samples.
-        req_samp_data.seg1 = delta_data.seg1->calc_req_samp(*blur_amt_data.seg1, img_size);
+        req_samp_data.seg1 = delta_data.seg1->calc_req_samp(blur_amt_data.seg1, img_size);
         int total_req_samp = *req_samp_data.seg1;
 
-        if (can_render_prev_2f) {
+        if (can_render_2f) {
             float adj = delta_data.seg1->get_scale();
-            req_samp_data.seg2 = delta_data.seg2->calc_req_samp(*blur_amt_data.seg2, img_size, adj);
+            req_samp_data.seg2 = delta_data.seg2->calc_req_samp(blur_amt_data.seg2, img_size, adj);
             total_req_samp = *req_samp_data.seg1 + *req_samp_data.seg2;
         }
 
@@ -522,39 +393,18 @@ process_object_motion_blur(lua_State *L) {
 
         SegData<int> samp_data = calc_samp(req_samp_data, params.samp_lim - 1, total_req_samp);
 
-        // Calculate the offset HTM (Homogeneous Transformation Matrix).
-        SegData<float> offset_amt_data = calc_offset_amt(params.shutter_angle, params.shutter_phase);
-        auto offset_mapping = Delta::calc_offset_mapping(delta_data, offset_amt_data, true);
-        htm_data.offset = offset_mapping.htm;
-
-        // Calculate the HTM.
-        htm_data.seg1 = delta_data.seg1->calc_htm(*blur_amt_data.seg1, *samp_data.seg1, true);
-        (*htm_data.seg1)[2] = offset_mapping.adj_mat * (*htm_data.seg1)[2];
-
-        if (can_render_prev_2f) {
-            htm_data.seg2 = delta_data.seg2->calc_htm(*blur_amt_data.seg2, *samp_data.seg2, true);
-            (*htm_data.seg2)[2] = offset_mapping.adj_mat * (*htm_data.seg2)[2];
-        }
-
-        // Calculate the step data.
-        auto offset_amt = calc_offset_amt(disp_data, params.shutter_angle, params.shutter_phase);
-        steps_data.offset = disp_data.seg1->calc_steps(offset_amt, 1, 0.0f);
-        steps_data.seg1 = disp_data.seg1->calc_steps(*blur_amt_data.seg1, *samp_data.seg1, steps_data.offset->rz_rad);
-        if (can_render_prev_2f) {
-            steps_data.seg2 =
-                    disp_data.seg2->calc_steps(*blur_amt_data.seg2, *samp_data.seg2, steps_data.offset->rz_rad);
-        }
+        // Calculate the HTMs (Homogeneous Transformation Matrix).
+        htm_data.offset = Delta::calc_offset_htm(delta_data, offset_amt_data, true);
+        htm_data.seg1 = delta_data.seg1->calc_htm(blur_amt_data.seg1, samp_data.seg1, true);
+        if (can_render_2f)
+            htm_data.seg2 = delta_data.seg2->calc_htm(blur_amt_data.seg2, samp_data.seg2, true);
 
         // Resize.
-        if (!params.keep_size) {
-            resize_image(static_cast<Vec2<int>>(img_size), center, disp_data, blur_amt_data, *steps_data.offset,
-                         delta_data.seg1->get_scale(), max_size, L);
-        }
+        if (!params.keep_size)
+            resize_img(L, can_render_2f, delta_data, offset_amt_data, blur_amt_data, center, img_size, max_size);
 
         // Rendering.
-        render_object_motion_blur(L, params, samp_data, htm_data);
-
-        //resize_img(L, delta_data, offset_amt_data, blur_amt_data, center, img_size, max_size);
+        render_object_motion_blur(L, can_render_2f, params, samp_data, htm_data);
 
         // Print information.params.is_printing_info_enabled
         if (params.print_info) {

--- a/dll_src/shared_memory.hpp
+++ b/dll_src/shared_memory.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <map>
@@ -26,8 +27,8 @@ public:
     void write(uint32_t key1, uint32_t key2, const T &val) {
         std::lock_guard<std::mutex> lock(mutex);
 
-        const size_t size = sizeof(T);
-        const size_t total_size = size << block_bits;
+        const std::size_t size = sizeof(T);
+        const std::size_t total_size = size << block_bits;
 
         uint32_t block_id, block_offset;
         calc_block_pos(key2, block_id, block_offset);
@@ -37,7 +38,8 @@ public:
         bool is_newly_created = false;
 
         if (old_handle == nullptr) {
-            new_handle = ::CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, total_size, nullptr); // 0 padding
+            new_handle = ::CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, total_size,
+                                             nullptr);  // 0 padding
             if (new_handle == nullptr)
                 return;
 
@@ -65,8 +67,8 @@ public:
     bool read(uint32_t key1, uint32_t key2, T &val) const {
         std::lock_guard<std::mutex> lock(mutex);
 
-        const size_t size = sizeof(T);
-        const size_t total_size = size << block_bits;
+        const std::size_t size = sizeof(T);
+        const std::size_t total_size = size << block_bits;
 
         uint32_t block_id, block_offset;
         calc_block_pos(key2, block_id, block_offset);

--- a/dll_src/structs.hpp
+++ b/dll_src/structs.hpp
@@ -36,6 +36,24 @@ struct SegmentData {
     SegmentData() : seg1(std::nullopt), seg2(std::nullopt), offset(std::nullopt) {}
 };
 
+template <typename T>
+struct SegData {
+    std::optional<T> seg1;
+    std::optional<T> seg2;
+
+    SegData() : seg1(std::nullopt), seg2(std::nullopt) {}
+    SegData(std::optional<T> s1, std::optional<T> s2) : seg1(s1), seg2(s2) {}
+};
+
+template <typename T>
+struct MappingData {
+    std::optional<T> offset;
+    std::optional<T> seg1;
+    std::optional<T> seg2;
+
+    MappingData() : offset(std::nullopt), seg1(std::nullopt), seg2(std::nullopt) {}
+};
+
 // The corner coordinates of the object in each frame as seen from the current object.
 struct Corner {
     Vec2<float> location;

--- a/dll_src/structs.hpp
+++ b/dll_src/structs.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #define NOMINMAX
 #include <exedit.hpp>
 
@@ -26,23 +27,20 @@ struct Geometry {
         is_valid(true), ox(ox_), oy(oy_), cx(cx_), cy(cy_), zoom(zoom_), rz(rz_) {}
 };
 
-// A structure to store data for each segment.
+// The structure to store data for each segment.
 template <typename T>
-struct SegmentData {
-    std::optional<T> seg1;
-    std::optional<T> seg2;
-    std::optional<T> offset;
-
-    SegmentData() : seg1(std::nullopt), seg2(std::nullopt), offset(std::nullopt) {}
+struct SegData {
+    T seg1;
+    T seg2;
 };
 
 template <typename T>
-struct SegData {
+struct OptSegData {
     std::optional<T> seg1;
     std::optional<T> seg2;
 
-    SegData() : seg1(std::nullopt), seg2(std::nullopt) {}
-    SegData(std::optional<T> s1, std::optional<T> s2) : seg1(s1), seg2(s2) {}
+    OptSegData() : seg1(std::nullopt), seg2(std::nullopt) {}
+    OptSegData(std::optional<T> s1, std::optional<T> s2) : seg1(s1), seg2(s2) {}
 };
 
 template <typename T>
@@ -52,19 +50,4 @@ struct MappingData {
     std::optional<T> seg2;
 
     MappingData() : offset(std::nullopt), seg1(std::nullopt), seg2(std::nullopt) {}
-};
-
-// The corner coordinates of the object in each frame as seen from the current object.
-struct Corner {
-    Vec2<float> location;
-    Vec2<int> upper_left;
-    Vec2<int> lower_right;
-
-    Corner() : location(0.0f, 0.0f), upper_left(0, 0), lower_right(0, 0) {}
-};
-
-// Blur step.
-struct Steps {
-    Vec2<float> location;
-    float scale, rz_rad;
 };

--- a/dll_src/transform_utils.cpp
+++ b/dll_src/transform_utils.cpp
@@ -4,10 +4,10 @@
 
 // Transform class
 // Constructor
-Transform::Transform(float x, float y, float zoom, float rz_deg, float cx, float cy) :
+Transform::Transform(float x, float y, float zoom, float rz_deg, float cx, float cy) noexcept :
     x(x), y(y), zoom(std::max(zoom, ZOOM_MIN)), rz_deg(rz_deg), rz_rad(to_rad(rz_deg)), cx(cx), cy(cy) {}
 
-Transform::Transform(const ObjectUtils &obj_utls, int offset_frame, OffsetType offset_type) :
+Transform::Transform(const ObjectUtils &obj_utls, int offset_frame, OffsetType offset_type) noexcept :
     x(obj_utls.calc_track_val(TrackName::X, offset_frame, offset_type)),
     y(obj_utls.calc_track_val(TrackName::Y, offset_frame, offset_type)),
     zoom(std::max(obj_utls.calc_track_val(TrackName::Zoom, offset_frame, offset_type), ZOOM_MIN)),
@@ -17,12 +17,7 @@ Transform::Transform(const ObjectUtils &obj_utls, int offset_frame, OffsetType o
     cy(obj_utls.get_cy()) {}
 
 void
-Transform::apply_geometry() {
-    zoom = ZOOM_MIN;
-}
-
-void
-Transform::apply_geometry(const Geometry &geo) {
+Transform::apply_geometry(const Geometry &geo) noexcept {
     x += ObjectUtils::calc_ox(geo.ox);
     y += ObjectUtils::calc_oy(geo.oy);
     zoom = std::max(zoom * ObjectUtils::calc_zoom(geo.zoom), ZOOM_MIN);
@@ -48,12 +43,12 @@ Displacements::Displacements(const Transform &from, const Transform &to) :
 
 // Calculate the required_samples.
 int
-Displacements::calc_required_samples(float blur_amount, const Vec2<int> &image_size, float scale) const {
+Displacements::calc_required_samples(float blur_amount, const Vec2<int> &image_size, float factor) const {
     if (!is_moved)
         return 0;
 
     Vec2<float> abs_center(std::abs(center_from.get_x()), std::abs(center_from.get_y()));
-    Vec2<float> size = static_cast<Vec2<float>>(image_size) * scale + abs_center;
+    Vec2<float> size = static_cast<Vec2<float>>(image_size) * factor + abs_center;
     float radius = size.norm(2) * 0.5f;
 
     return std::max({static_cast<int>(std::ceil(std::abs(local_distance) * blur_amount)),

--- a/dll_src/transform_utils.cpp
+++ b/dll_src/transform_utils.cpp
@@ -2,9 +2,9 @@
 
 #include <algorithm>
 #include <cmath>
+#include <optional>
 
-// Transform class
-// Constructor
+// Transform class.
 Transform::Transform(float x, float y, float zoom, float rz_deg, float cx, float cy) noexcept :
     x(x), y(y), zoom(std::max(zoom, ZOOM_MIN)), rz_deg(rz_deg), rz_rad(to_rad(rz_deg)), cx(cx), cy(cy) {}
 
@@ -26,6 +26,7 @@ Transform::apply_geometry(const Geometry &geo) noexcept {
     rz_rad = to_rad(rz_deg);
 }
 
+// Delta class.
 Delta::Delta(const Transform &from, const Transform &to) noexcept :
     rel_rot(to.rz_rad - from.rz_rad),
     rel_scale(std::max(to.zoom / from.zoom, ZOOM_MIN)),
@@ -33,139 +34,47 @@ Delta::Delta(const Transform &from, const Transform &to) noexcept :
     center_to(-to.get_center()),
     center_from(-from.get_center()),
     rel_dist(rel_pos.norm(2)),
-    is_moved(!is_zero(rel_dist) || !are_equal(rel_scale, 1.0f) || !is_zero(rel_rot)) {}
+    is_moved(!is_zero(rel_dist) || !are_equal(rel_scale, 1.0f) || !is_zero(rel_rot)),
+    init_data() {}
 
-Delta::Mapping
-Delta::calc_offset_mapping(const SegData<Delta> &delta_data, const SegData<float> &amt_data, bool is_inv) noexcept {
-    float offset_rot = delta_data.seg1->get_rot() * *amt_data.seg1;
-    float offset_scale = std::pow(delta_data.seg1->get_scale(), *amt_data.seg1);
-    auto offset_pos = delta_data.seg1->get_pos() * *amt_data.seg1;
+Mat3<float>
+Delta::calc_offset_htm(OptSegData<Delta> &delta_data, const SegData<float> &offset_amt_data, bool is_inv) noexcept {
+    float offset_rot = delta_data.seg1->get_rot() * offset_amt_data.seg1;
+    float offset_scale = std::pow(delta_data.seg1->get_scale(), offset_amt_data.seg1);
+    auto offset_pos = delta_data.seg1->get_pos() * offset_amt_data.seg1;
 
-    if (amt_data.seg2) {
-        offset_rot += delta_data.seg2->get_rot() * *amt_data.seg2;
-        offset_scale *= std::pow(delta_data.seg2->get_scale(), *amt_data.seg2);
+    if (delta_data.seg2) {
+        offset_rot += delta_data.seg2->get_rot() * offset_amt_data.seg2;
+        offset_scale *= std::pow(delta_data.seg2->get_scale(), offset_amt_data.seg2);
         auto pos_seg2 = delta_data.seg2->get_pos();
-        offset_pos += pos_seg2.rotate(delta_data.seg1->get_rot(), delta_data.seg1->get_scale()) * *amt_data.seg2;
+        offset_pos += pos_seg2.rotate(delta_data.seg1->get_rot(), delta_data.seg1->get_scale()) * offset_amt_data.seg2;
     }
 
-    auto htm = calc_htm_impl(offset_rot, offset_scale, offset_pos, is_inv);
-    auto adj_mat = htm;
-    adj_mat[2] = Vec3<float>(0.0f, 0.0f, 1.0f);
+    std::optional<Delta::Init> new_init;
 
-    return {htm, adj_mat};
+    if (!delta_data.seg1->get_init().is_valid) {
+        if (!new_init)
+            new_init.emplace(true, Mat2<float>::rotation(-offset_rot, 1.0f / offset_scale));
+
+        delta_data.seg1->set_init(*new_init);
+    }
+
+    if (delta_data.seg2 && !delta_data.seg2->get_init().is_valid) {
+        if (!new_init)
+            new_init.emplace(true, Mat2<float>::rotation(-offset_rot, 1.0f / offset_scale));
+
+        delta_data.seg2->set_init(*new_init);
+    }
+
+    return calc_htm_impl(offset_rot, offset_scale, offset_pos, is_inv);
 }
 
 Mat3<float>
 Delta::calc_htm(float amt, int samp, bool is_inv) const noexcept {
-    float step_amt = amt / static_cast<float>(samp);
+    float step_amt = samp > 1 ? amt / static_cast<float>(samp) : amt;
     float step_rot = rel_rot * step_amt;
     float step_scale = std::pow(rel_scale, step_amt);
-    auto step_pos = rel_pos * step_amt;
+    auto step_pos = init_data.orientation * (rel_pos * step_amt);
 
     return calc_htm_impl(step_rot, step_scale, step_pos, is_inv);
-}
-
-Vec2<float>
-Delta::calc_bbox(const Vec2<float> &img_size, float amt, float offset_rot) const noexcept {
-    if (is_zero(amt) && is_zero(offset_rot)) {
-        return img_size;
-    } else {
-        float theta = rel_rot * amt - offset_rot;
-        auto rot_mat = Mat2<float>::rotation(theta);
-        Vec2<float> size = img_size * (1.0f + (rel_scale - 1.0f) * amt);
-        return rot_mat.abs() * size;
-    }
-}
-
-// Displacements class
-// Constructor
-// Constructor with parameters
-Displacements::Displacements(const Transform &from, const Transform &to) :
-    global_location((to.get_location() - from.get_location())),
-    global_distance(global_location.norm(2)),
-    local_location(global_location.rotate(-from.get_rz(), 100.0f / from.get_zoom())),
-    local_distance(local_location.norm(2)),
-    global_zoom((to.get_zoom() - from.get_zoom())),
-    local_zoom(global_zoom / from.get_zoom()),
-    rz_deg((to.get_rz(AngleUnit::Deg) - from.get_rz(AngleUnit::Deg))),
-    rz_rad(to.get_rz() - from.get_rz()),
-    is_moved(!are_equal(global_distance, 0.0f) || !are_equal(global_zoom, 0.0f) || !are_equal(rz_deg, 0.0f)),
-    center_from(from.get_center()),
-    center_to(to.get_center()) {}
-
-// Calculate the required_samples.
-int
-Displacements::calc_required_samples(float blur_amount, const Vec2<int> &image_size, float factor) const {
-    if (!is_moved)
-        return 0;
-
-    Vec2<float> abs_center(std::abs(center_from.get_x()), std::abs(center_from.get_y()));
-    Vec2<float> size = static_cast<Vec2<float>>(image_size) * factor + abs_center;
-    float radius = size.norm(2) * 0.5f;
-
-    return std::max({static_cast<int>(std::ceil(std::abs(local_distance) * blur_amount)),
-                     static_cast<int>(std::ceil(std::abs(local_zoom) * radius * blur_amount)),
-                     static_cast<int>(std::ceil(std::abs(rz_rad) * radius * blur_amount)), 0});
-}
-
-// Calculate the relative_displacements (ratio).
-std::tuple<float, float, float>
-Displacements::calc_relative_displacements(const Displacements &other) const {
-    if (!is_moved || !other.is_moved) {
-        return {0.0f, 0.0f, 0.0f};
-    }
-
-    return {!are_equal(other.global_distance, 0.0f) ? global_distance / other.global_distance : 0.0f,
-            !are_equal(other.global_zoom, 0.0f) ? global_zoom / other.global_zoom : 0.0f,
-            !are_equal(other.rz_deg, 0.0f) ? rz_deg / other.rz_deg : 0.0f};
-}
-
-// Calculate the step values.
-Steps
-Displacements::calc_steps_impl(float loc_amount, float scale_amount, float rz_amount, int samples,
-                               float offset_angle_rad) const {
-    if (!is_moved)
-        return Steps{Vec2<float>(0.0f, 0.0f), 1.0f, 0.0f};
-
-    float inv_samples = 1.0f / static_cast<float>(std::max(1, samples));
-    Vec2<float> step_location = local_location.rotate(offset_angle_rad, loc_amount * inv_samples);
-    float step_scale = std::pow(std::max(1.0f + local_zoom * scale_amount, ZOOM_MIN), inv_samples);
-    float step_rz_rad = rz_rad * rz_amount * inv_samples;
-
-    return Steps{step_location, step_scale, step_rz_rad};
-}
-
-Vec2<float>
-Displacements::calc_relative_location(float amount, float offset_angle_rad) const {
-    if (are_equal(amount, 0.0f)) {
-        return center_from.rotate(-offset_angle_rad) - center_to.rotate(-offset_angle_rad);
-    } else if (are_equal(amount, 1.0f)) {
-        Vec2<float> rotated_from = center_from.rotate(-offset_angle_rad);
-        Vec2<float> rotated_to = center_to.rotate(rz_rad - offset_angle_rad, calc_relative_scale());
-
-        return rotated_from + local_location - rotated_to;
-    } else {
-        Vec2<float> rotated_from = center_from.rotate(-offset_angle_rad);
-        Vec2<float> scaled_local = local_location * amount;
-        Vec2<float> rotated_to = center_to.rotate(rz_rad * amount - offset_angle_rad, calc_relative_scale(amount));
-
-        return rotated_from + scaled_local - rotated_to;
-    }
-}
-
-Vec2<float>
-Displacements::calc_bounding_box_size(const Vec2<int> &image_size, float amount, float offset_angle_rad) const {
-    if (are_equal(amount, 0.0f) && are_equal(offset_angle_rad, 0.0f)) {
-        return static_cast<Vec2<float>>(image_size);
-    } else {
-        float angle = rz_rad * amount - offset_angle_rad;
-        float cos = std::cos(angle);
-        float sin = std::sin(angle);
-        Vec2<float> image = static_cast<Vec2<float>>(image_size) * calc_relative_scale(amount);
-
-        float w = std::abs(image.get_x() * cos) + std::abs(image.get_y() * sin);
-        float h = std::abs(image.get_x() * sin) + std::abs(image.get_y() * cos);
-
-        return Vec2<float>(w, h);
-    }
 }

--- a/dll_src/transform_utils.hpp
+++ b/dll_src/transform_utils.hpp
@@ -2,8 +2,8 @@
 
 #include "aul_utils.hpp"
 #include "structs.hpp"
-#include "vector_2d.hpp"
 #include "utils.hpp"
+#include "vector_2d.hpp"
 
 #define ZOOM_MIN 1e-2f
 
@@ -19,20 +19,19 @@ enum class Coords : int {
 
 class Transform {
 public:
-    Transform(float x = 0.0f, float y = 0.0f, float zoom = 1.0f, float rz_deg = 0.0f, float cx = 0.0f, float cy = 0.0f);
-    Transform(const ObjectUtils &obj_utls, int offset_frame = 0, OffsetType offset_type = OffsetType::Current);
+    Transform(float x = 0.0f, float y = 0.0f, float zoom = 1.0f, float rz_deg = 0.0f, float cx = 0.0f, float cy = 0.0f) noexcept;
+    Transform(const ObjectUtils &obj_utls, int offset_frame = 0, OffsetType offset_type = OffsetType::Current) noexcept;
 
-    Transform operator+(const Transform &other) const;
-    Transform operator-(const Transform &other) const;
-    Transform operator*(const float &scalar) const;
+    [[nodiscard]] Transform operator+(const Transform &other) const noexcept;
+    [[nodiscard]] Transform operator-(const Transform &other) const noexcept;
+    [[nodiscard]] Transform operator*(float scalar) const noexcept;
 
     Vec2<float> get_location() const;
     float get_zoom() const;
     float get_rz(AngleUnit unit = AngleUnit::Rad) const;
     Vec2<float> get_center() const;
 
-    void apply_geometry();
-    void apply_geometry(const Geometry &geo);
+    void apply_geometry(const Geometry &geo) noexcept;
 
 private:
     float x, y, zoom, rz_deg, rz_rad, cx, cy;
@@ -48,7 +47,7 @@ public:
     float get_rz(AngleUnit unit = AngleUnit::Rad) const;
     bool get_is_moved() const;
 
-    int calc_required_samples(float blur_amount, const Vec2<int> &image_size, float scale) const;
+    int calc_required_samples(float blur_amount, const Vec2<int> &image_size, float factor) const;
     std::tuple<float, float, float> calc_relative_displacements(const Displacements &other) const;
     Steps calc_steps(float amount, int samples, float offset_angle_rad) const;
     Steps calc_steps(const std::array<float, 3> &amount, int samples, float offset_angle_rad) const;
@@ -71,17 +70,17 @@ private:
 
 // Overload the +, -, and * operators for Transform class.
 inline Transform
-Transform::operator+(const Transform &other) const {
+Transform::operator+(const Transform &other) const noexcept {
     return Transform(x + other.x, y + other.y, zoom + other.zoom, rz_deg + other.rz_deg, cx + other.cx, cy + other.cy);
 }
 
 inline Transform
-Transform::operator-(const Transform &other) const {
+Transform::operator-(const Transform &other) const noexcept {
     return Transform(x - other.x, y - other.y, zoom - other.zoom, rz_deg - other.rz_deg, cx - other.cx, cy - other.cy);
 }
 
 inline Transform
-Transform::operator*(const float &scalar) const {
+Transform::operator*(float scalar) const noexcept {
     return Transform(x * scalar, y * scalar, zoom * scalar, rz_deg * scalar, cx * scalar, cy * scalar);
 }
 

--- a/dll_src/transform_utils.hpp
+++ b/dll_src/transform_utils.hpp
@@ -8,7 +8,7 @@
 #include "vector_2d.hpp"
 #include "vector_3d.hpp"
 
-#define ZOOM_MIN 1.0e-2f
+#define ZOOM_MIN 1.0e-4f
 
 enum class AngleUnit : int {
     Rad,
@@ -43,7 +43,7 @@ struct Transform {
 
 class Delta {
 public:
-    // HTM (Homogeneous Transformation Matrix) & Adjustment Matrix (Inverse of the orientation).
+    // HTM (Homogeneous Transformation Matrix) & Adjustment Matrix (Orientation Matrix).
     struct Mapping {
         Mat3<float> htm;
         Mat3<float> adj_mat;
@@ -53,15 +53,22 @@ public:
     Delta(const Transform &from, const Transform &to) noexcept;
 
     // Getters.
+    [[nodiscard]] constexpr const float &get_rot() const noexcept { return rel_rot; }
     [[nodiscard]] constexpr const float &get_scale() const noexcept { return rel_scale; }
+    [[nodiscard]] constexpr const Vec2<float> &get_pos() const noexcept { return rel_pos; }
     [[nodiscard]] constexpr const Vec2<float> &get_center() const noexcept { return center_to; }
     [[nodiscard]] constexpr const bool &get_is_moved() const noexcept { return is_moved; }
 
     // Calculate the required samples.
-    [[nodiscard]] int calc_req_samp(float amt, const Vec2<float> &img_size, float adj = 1.0f) const noexcept;
+    [[nodiscard]] constexpr int calc_req_samp(float amt, const Vec2<float> &img_size, float adj = 1.0f) const noexcept;
 
-    // Calculate the mapping structure.
-    [[nodiscard]] Mat3<float> calc_htm(float amt = 1.0f, bool is_inv = false, int samp = 1) const noexcept;
+    // Calculate the offset mapping data.
+    [[nodiscard]] static Mapping calc_offset_mapping(const SegData<Delta> &delta_data,
+                                                     const SegData<float> &offset_amt_data,
+                                                     bool is_inv = false) noexcept;
+
+    // Calculate the HTM (Homogeneous Transformation Matrix).
+    [[nodiscard]] Mat3<float> calc_htm(float amt = 1.0f, int samp = 1, bool is_inv = false) const noexcept;
 
     // Calculate the bounding box size.
     [[nodiscard]] Vec2<float> calc_bbox(const Vec2<float> &img_size, float amt = 1.0f,
@@ -72,7 +79,36 @@ private:
     Vec2<float> rel_pos, center_to, center_from;
     float rel_dist;
     bool is_moved;
+
+    [[nodiscard]] static constexpr Mat3<float> calc_htm_impl(float rot, float scale, const Vec2<float> &pos,
+                                                             bool is_inv) noexcept;
 };
+
+inline constexpr int
+Delta::calc_req_samp(float amt, const Vec2<float> &img_size, float adj) const noexcept {
+    if (!is_moved)
+        return 0;
+
+    auto size = img_size + center_from.abs();
+    float r = size.norm(2) * 0.5f;
+
+    auto req_samps = Vec3<float>(rel_dist, (rel_scale - 1.0f) * r, rel_rot * r) * amt;
+    return static_cast<int>(std::ceil(req_samps.norm(-1) * adj));
+}
+
+inline constexpr Mat3<float>
+Delta::calc_htm_impl(float rot, float scale, const Vec2<float> &pos, bool is_inv) noexcept {
+    if (is_inv) {
+        auto inv_ori = Mat2<float>::rotation(-rot, 1.0f / scale);
+        auto inv_step_pos = -(inv_ori * pos);
+        auto trans = Vec3<float>(inv_step_pos, 1.0f);
+        return Mat3<float>(inv_ori, trans);
+    } else {
+        auto ori = Mat2<float>::rotation(rot, scale);
+        auto trans = Vec3<float>(pos, 1.0f);
+        return Mat3<float>(ori, trans);
+    }
+}
 
 class Displacements {
 public:

--- a/dll_src/transform_utils.hpp
+++ b/dll_src/transform_utils.hpp
@@ -8,7 +8,7 @@
 #include "vector_2d.hpp"
 #include "vector_3d.hpp"
 
-#define ZOOM_MIN 1e-2f
+#define ZOOM_MIN 1.0e-2f
 
 enum class AngleUnit : int {
     Rad,
@@ -43,24 +43,28 @@ struct Transform {
 
 class Delta {
 public:
-    using htm_and_adj = std::pair<Mat3<float>, Mat3<float>>;
+    // HTM (Homogeneous Transformation Matrix) & Adjustment Matrix (Inverse of the orientation).
+    struct Mapping {
+        Mat3<float> htm;
+        Mat3<float> adj;
+    };
 
     // Constructors.
     Delta(const Transform &from, const Transform &to) noexcept;
 
     // Getters.
-    [[nodiscard]] constexpr const bool &get_is_moved() const noexcept { return is_moved; }
+    [[nodiscard]] constexpr const float &get_scale() const noexcept { return rel_scale; }
     [[nodiscard]] constexpr const Vec2<float> &get_center() const noexcept { return center_to; }
+    [[nodiscard]] constexpr const bool &get_is_moved() const noexcept { return is_moved; }
 
     // Calculate the required samples.
-    [[nodiscard]] int calc_req_samp(float amt, const Vec2<int> &img_size, float img_scale) const noexcept;
+    [[nodiscard]] int calc_req_samp(float amt, const Vec2<float> &img_size, float img_scale = 1.0f) const noexcept;
 
-    // Calculate the HTM (Homogeneous Transformation Matrix).
-    // Out: 1. HTM, 2. Adjustment Matrix (Inverse of the orientation).
-    [[nodiscard]] htm_and_adj calc_htm(bool is_inv = false, int samp = 1, float amt = 1.0f) const noexcept;
+    // Calculate the mapping structure.
+    [[nodiscard]] Mapping calc_mapping(bool is_inv = false, float amt = 1.0f, int samp = 1) const noexcept;
 
     // Calculate the bounding box size.
-    [[nodiscard]] Vec2<float> calc_bbox(const Vec2<int> &img_size, float amt = 1.0f,
+    [[nodiscard]] Vec2<float> calc_bbox(const Vec2<float> &img_size, float amt = 1.0f,
                                         float offset_rot = 0.0f) const noexcept;
 
 private:

--- a/dll_src/transform_utils.hpp
+++ b/dll_src/transform_utils.hpp
@@ -46,7 +46,7 @@ public:
     // HTM (Homogeneous Transformation Matrix) & Adjustment Matrix (Inverse of the orientation).
     struct Mapping {
         Mat3<float> htm;
-        Mat3<float> adj;
+        Mat3<float> adj_mat;
     };
 
     // Constructors.
@@ -58,10 +58,10 @@ public:
     [[nodiscard]] constexpr const bool &get_is_moved() const noexcept { return is_moved; }
 
     // Calculate the required samples.
-    [[nodiscard]] int calc_req_samp(float amt, const Vec2<float> &img_size, float img_scale = 1.0f) const noexcept;
+    [[nodiscard]] int calc_req_samp(float amt, const Vec2<float> &img_size, float adj = 1.0f) const noexcept;
 
     // Calculate the mapping structure.
-    [[nodiscard]] Mapping calc_mapping(bool is_inv = false, float amt = 1.0f, int samp = 1) const noexcept;
+    [[nodiscard]] Mat3<float> calc_htm(float amt = 1.0f, bool is_inv = false, int samp = 1) const noexcept;
 
     // Calculate the bounding box size.
     [[nodiscard]] Vec2<float> calc_bbox(const Vec2<float> &img_size, float amt = 1.0f,

--- a/dll_src/transform_utils.hpp
+++ b/dll_src/transform_utils.hpp
@@ -10,16 +10,6 @@
 
 #define ZOOM_MIN 1.0e-4f
 
-enum class AngleUnit : int {
-    Rad,
-    Deg
-};
-
-enum class Coords : int {
-    Global,
-    Local
-};
-
 struct Transform {
     float x, y, zoom, rz_deg, rz_rad, cx, cy;
 
@@ -32,9 +22,6 @@ struct Transform {
     [[nodiscard]] Transform operator-(const Transform &other) const noexcept;
     [[nodiscard]] Transform operator*(float scalar) const noexcept;
 
-    Vec2<float> get_location() const;
-    float get_zoom() const;
-    float get_rz(AngleUnit unit = AngleUnit::Rad) const;
     [[nodiscard]] constexpr Vec2<float> get_pos() const noexcept { return Vec2<float>(x, y); }
     [[nodiscard]] constexpr Vec2<float> get_center() const noexcept { return Vec2<float>(cx, cy); }
 
@@ -43,10 +30,18 @@ struct Transform {
 
 class Delta {
 public:
-    // HTM (Homogeneous Transformation Matrix) & Adjustment Matrix (Orientation Matrix).
+    // HTM (Homogeneous Transformation Matrix) & Adjustment Matrix (Inverse Orientation Matrix).
     struct Mapping {
         Mat3<float> htm;
         Mat3<float> adj_mat;
+    };
+
+    struct Init {
+        bool is_valid;
+        Mat2<float> orientation;
+
+        Init() : is_valid(false), orientation() {}
+        Init(bool valid, const Mat2<float> &mat) : is_valid(valid), orientation(mat) {}
     };
 
     // Constructors.
@@ -58,27 +53,28 @@ public:
     [[nodiscard]] constexpr const Vec2<float> &get_pos() const noexcept { return rel_pos; }
     [[nodiscard]] constexpr const Vec2<float> &get_center() const noexcept { return center_to; }
     [[nodiscard]] constexpr const bool &get_is_moved() const noexcept { return is_moved; }
+    [[nodiscard]] constexpr const Init &get_init() const noexcept { return init_data; }
+
+    // Setters.
+    constexpr void set_init(const Init &new_init) noexcept { init_data = new_init; }
 
     // Calculate the required samples.
     [[nodiscard]] constexpr int calc_req_samp(float amt, const Vec2<float> &img_size, float adj = 1.0f) const noexcept;
 
     // Calculate the offset mapping data.
-    [[nodiscard]] static Mapping calc_offset_mapping(const SegData<Delta> &delta_data,
+    [[nodiscard]] static Mat3<float> calc_offset_htm(OptSegData<Delta> &delta_data,
                                                      const SegData<float> &offset_amt_data,
                                                      bool is_inv = false) noexcept;
 
     // Calculate the HTM (Homogeneous Transformation Matrix).
     [[nodiscard]] Mat3<float> calc_htm(float amt = 1.0f, int samp = 1, bool is_inv = false) const noexcept;
 
-    // Calculate the bounding box size.
-    [[nodiscard]] Vec2<float> calc_bbox(const Vec2<float> &img_size, float amt = 1.0f,
-                                        float offset_rot = 0.0f) const noexcept;
-
 private:
     float rel_rot, rel_scale;
     Vec2<float> rel_pos, center_to, center_from;
     float rel_dist;
     bool is_moved;
+    Init init_data;
 
     [[nodiscard]] static constexpr Mat3<float> calc_htm_impl(float rot, float scale, const Vec2<float> &pos,
                                                              bool is_inv) noexcept;
@@ -110,37 +106,6 @@ Delta::calc_htm_impl(float rot, float scale, const Vec2<float> &pos, bool is_inv
     }
 }
 
-class Displacements {
-public:
-    Displacements(const Transform &from, const Transform &to);
-
-    Vec2<float> get_location(Coords coords = Coords::Local) const;
-    float get_distance(Coords coords = Coords::Local) const;
-    float get_zoom(Coords coords = Coords::Local) const;
-    float get_rz(AngleUnit unit = AngleUnit::Rad) const;
-    bool get_is_moved() const;
-
-    int calc_required_samples(float blur_amount, const Vec2<int> &image_size, float factor) const;
-    std::tuple<float, float, float> calc_relative_displacements(const Displacements &other) const;
-    Steps calc_steps(float amount, int samples, float offset_angle_rad) const;
-    Steps calc_steps(const std::array<float, 3> &amount, int samples, float offset_angle_rad) const;
-    Vec2<float> calc_relative_location(float amount = 1.0f, float offset_angle_rad = 0.0f) const;
-    float calc_relative_scale(float amount = 1.0f) const;
-    Vec2<float> calc_bounding_box_size(const Vec2<int> &image_size, float amount = 1.0f,
-                                       float offset_angle_rad = 0.0f) const;
-
-private:
-    Vec2<float> global_location, local_location;
-    float global_distance, local_distance;
-    float global_zoom, local_zoom;
-    float rz_deg, rz_rad;
-    bool is_moved;
-    Vec2<float> center_from;
-    Vec2<float> center_to;
-
-    Steps calc_steps_impl(float loc_amount, float s_amount, float rz_amount, int samples, float offset_angle_rad) const;
-};
-
 // Overload the +, -, and * operators for Transform class.
 inline Transform
 Transform::operator+(const Transform &other) const noexcept {
@@ -155,100 +120,4 @@ Transform::operator-(const Transform &other) const noexcept {
 inline Transform
 Transform::operator*(float scalar) const noexcept {
     return Transform(x * scalar, y * scalar, zoom * scalar, rz_deg * scalar, cx * scalar, cy * scalar);
-}
-
-// Transform Getters
-inline Vec2<float>
-Transform::get_location() const {
-    return Vec2<float>(x, y);
-}
-
-inline float
-Transform::get_zoom() const {
-    return zoom;
-}
-
-inline float
-Transform::get_rz(AngleUnit unit) const {
-    switch (unit) {
-        case AngleUnit::Rad:
-            return rz_rad;
-        case AngleUnit::Deg:
-            return rz_deg;
-        default:
-            return 0.0f;  // Invalid unit, return 0.0f
-    }
-}
-
-// Displacements Getters
-inline Vec2<float>
-Displacements::get_location(Coords coords) const {
-    switch (coords) {
-        case Coords::Global:
-            return global_location;
-        case Coords::Local:
-            return local_location;
-        default:
-            return Vec2<float>(0.0f, 0.0f);  // Invalid coordinate system, return zero vector
-    }
-}
-
-inline float
-Displacements::get_distance(Coords coords) const {
-    switch (coords) {
-        case Coords::Global:
-            return global_distance;
-        case Coords::Local:
-            return local_distance;
-        default:
-            return 0.0f;  // Invalid coordinate system, return 0.0f
-    }
-}
-
-inline float
-Displacements::get_zoom(Coords coords) const {
-    switch (coords) {
-        case Coords::Global:
-            return global_zoom;
-        case Coords::Local:
-            return local_zoom;
-        default:
-            return 0.0f;  // Invalid coordinate system, return 0.0f
-    }
-}
-
-inline float
-Displacements::get_rz(AngleUnit unit) const {
-    switch (unit) {
-        case AngleUnit::Rad:
-            return rz_rad;
-        case AngleUnit::Deg:
-            return rz_deg;
-        default:
-            return 0.0f;  // Invalid unit, return 0.0f
-    }
-}
-
-inline bool
-Displacements::get_is_moved() const {
-    return is_moved;
-}
-
-// Displacements Methods
-// Calculate the step values.
-inline Steps
-Displacements::calc_steps(float amount, int samples, float offset_angle_rad) const {
-    return calc_steps_impl(amount, amount, amount, samples, offset_angle_rad);
-}
-
-inline Steps
-Displacements::calc_steps(const std::array<float, 3> &amount, int samples, float offset_angle_rad) const {
-    const auto &[loc_amount, scale_amount, rz_amount] = amount;
-    return calc_steps_impl(loc_amount, scale_amount, rz_amount, samples, offset_angle_rad);
-}
-
-// Calculate the scale (to / from).
-inline float
-Displacements::calc_relative_scale(float amount) const {
-    return are_equal(amount, 0.0f) ? 1.0f : std::max(1.0f + local_zoom * amount, ZOOM_MIN);
 }

--- a/dll_src/utils.hpp
+++ b/dll_src/utils.hpp
@@ -14,6 +14,12 @@
 #endif
 
 inline bool
+is_zero(float val) {
+    constexpr float epsilon = 1e-4f;
+    return std::fabsf(val) <= epsilon;
+}
+
+inline bool
 are_equal(float a, float b) {
     constexpr float epsilon = 1e-4f;
     return std::fabsf(a - b) <= epsilon;

--- a/dll_src/utils.hpp
+++ b/dll_src/utils.hpp
@@ -15,13 +15,13 @@
 
 inline bool
 is_zero(float val) {
-    constexpr float epsilon = 1e-4f;
+    constexpr float epsilon = 1.0e-4f;
     return std::fabsf(val) <= epsilon;
 }
 
 inline bool
 are_equal(float a, float b) {
-    constexpr float epsilon = 1e-4f;
+    constexpr float epsilon = 1.0e-4f;
     return std::fabsf(a - b) <= epsilon;
 }
 

--- a/dll_src/vector_2d.hpp
+++ b/dll_src/vector_2d.hpp
@@ -1,23 +1,20 @@
 #pragma once
 
-#include <algorithm>
 #include <array>
 #include <cmath>
-#include <limits>
+#include <concepts>
 #include <ostream>
 #include <stdexcept>
-#include <type_traits>
 
-template <typename T>
-concept arithmetic = std::integral<T> || std::floating_point<T>;
+#include "vector_base.hpp"
 
 // Define a 2D vector class template.
-template <arithmetic T>
-class Vec2 {
+template <vec_base::arithmetic T>
+class Vec2 : public vec_base::VecBase<Vec2<T>, 2, T> {
 public:
     // Constructors.
-    constexpr Vec2() noexcept : x(T(0)), y(T(0)) {}
-    constexpr Vec2(T x, T y) noexcept : x(x), y(y) {}
+    constexpr Vec2() noexcept : super() {}
+    constexpr Vec2(T x, T y) noexcept : super(x, y) {}
     constexpr Vec2(const Vec2 &other) noexcept = default;
     constexpr Vec2(Vec2 &&other) noexcept = default;
 
@@ -25,152 +22,47 @@ public:
     constexpr Vec2 &operator=(const Vec2 &other) noexcept = default;
     constexpr Vec2 &operator=(Vec2 &&other) noexcept = default;
 
-    // Operators.
-    [[nodiscard]] constexpr Vec2 operator+(const Vec2 &other) const noexcept { return Vec2(x + other.x, y + other.y); }
-
-    [[nodiscard]] constexpr Vec2 operator-(const Vec2 &other) const noexcept { return Vec2(x - other.x, y - other.y); }
-
-    [[nodiscard]] constexpr Vec2 operator*(T scalar) const noexcept { return Vec2(x * scalar, y * scalar); }
-
-    [[nodiscard]] constexpr Vec2 operator/(T scalar) const {
-        if (is_zero(scalar)) {
-            throw std::invalid_argument("Division by zero in Vec2.");
-        }
-        return Vec2(x / scalar, y / scalar);
-    }
-
-    // Compound assignment operators.
-    constexpr Vec2 &operator+=(const Vec2 &other) noexcept {
-        x += other.x;
-        y += other.y;
-        return *this;
-    }
-
-    constexpr Vec2 &operator-=(const Vec2 &other) noexcept {
-        x -= other.x;
-        y -= other.y;
-        return *this;
-    }
-
-    constexpr Vec2 &operator*=(T scalar) noexcept {
-        x *= scalar;
-        y *= scalar;
-        return *this;
-    }
-
-    constexpr Vec2 &operator/=(T scalar) {
-        if (is_zero(scalar)) {
-            throw std::invalid_argument("Division by zero in Vec2.");
-        }
-        x /= scalar;
-        y /= scalar;
-        return *this;
-    }
-
-    [[nodiscard]] constexpr bool operator==(const Vec2 &other) const noexcept {
-        if constexpr (std::is_floating_point_v<T>) {
-            return std::abs(x - other.x) <= epsilon() && std::abs(y - other.y) <= epsilon();
-        } else {
-            return x == other.x && y == other.y;
-        }
-    }
-
-    [[nodiscard]] constexpr bool operator!=(const Vec2 &other) const noexcept { return !(*this == other); }
-
-    template <arithmetic U>
+    // Type conversion operator.
+    template <vec_base::arithmetic U>
     [[nodiscard]] explicit constexpr operator Vec2<U>() const noexcept {
-        return Vec2<U>(static_cast<U>(x), static_cast<U>(y));
+        return Vec2<U>(static_cast<U>(get_x()), static_cast<U>(get_y()));
     }
 
     // Getters.
-    [[nodiscard]] constexpr T get_x() const noexcept { return x; }
-    [[nodiscard]] constexpr T get_y() const noexcept { return y; }
+    [[nodiscard]] constexpr const T &get_x() const noexcept { return this->data[0]; }
+    [[nodiscard]] constexpr const T &get_y() const noexcept { return this->data[1]; }
 
     // Setters.
-    constexpr void set_x(T new_x) noexcept { x = new_x; }
-    constexpr void set_y(T new_y) noexcept { y = new_y; }
-
-    // Norm calculation.
-    [[nodiscard]] T norm(int ord = 2) const {
-        switch (ord) {
-            case 1:
-                return std::abs(x) + std::abs(y);  // Manhattan norm (L1 norm)
-            case 2:
-                if constexpr (std::is_floating_point_v<T>)
-                    return std::sqrt(x * x + y * y);  // Euclidean norm (L2)
-                else
-                    return static_cast<T>(std::sqrt(static_cast<double>(x * x + y * y)));
-            case -1:
-                return std::max(std::abs(x), std::abs(y));  // Maximum norm (L inf norm)
-            default:
-                throw std::invalid_argument("Unsupported norm order.");
-        }
-    }
+    constexpr void set_x(T new_x) noexcept { this->data[0] = new_x; }
+    constexpr void set_y(T new_y) noexcept { this->data[1] = new_y; }
 
     // Rotation function.
     // The rotation is performed around the origin (0, 0) using the standard 2D rotation matrix.
-    [[nodiscard]] Vec2 rotate(T theta = T(0), T factor = T(1)) const {
-        if (is_zero(theta))
-            return Vec2(factor * x, factor * y);
-
-        if constexpr (std::is_floating_point_v<T>) {
-            T cos_t = std::cos(theta);
-            T sin_t = std::sin(theta);
-            return Vec2(factor * (x * cos_t - y * sin_t), factor * (x * sin_t + y * cos_t));
-        } else {
-            double cos_t = std::cos(static_cast<double>(theta));
-            double sin_t = std::sin(static_cast<double>(theta));
-            double fx = static_cast<double>(factor * x);
-            double fy = static_cast<double>(factor * y);
-            return Vec2(static_cast<T>(fx * cos_t - fy * sin_t), static_cast<T>(fx * sin_t + fy * cos_t));
-        }
-    }
-
-    // Ceiling function.
-    [[nodiscard]] Vec2 ceil() const
-        requires std::is_floating_point_v<T>
+    [[nodiscard]] constexpr Vec2 rotate(T theta = T{0}, T scale = T{1}) const noexcept
+        requires std::floating_point<T>
     {
-        return Vec2(std::ceil(x), std::ceil(y));
-    }
+        if (this->is_zero(theta))
+            return Vec2(scale * get_x(), scale * get_y());
 
-    // Floor function.
-    [[nodiscard]] Vec2 floor() const
-        requires std::is_floating_point_v<T>
-    {
-        return Vec2(std::floor(x), std::floor(y));
-    }
+        T cos_t = std::cos(theta);
+        T sin_t = std::sin(theta);
 
-    // epsilon value for floating-point comparison.
-    [[nodiscard]] static constexpr T epsilon() noexcept {
-        if constexpr (std::is_floating_point_v<T>) {
-            return std::numeric_limits<T>::epsilon() * 1000;
-        } else {
-            return T(0);
-        }
-    }
-
-    // Check if the value is zero.
-    [[nodiscard]] static constexpr bool is_zero(T val) noexcept {
-        if constexpr (std::is_floating_point_v<T>) {
-            return std::abs(val) <= epsilon();
-        } else {
-            return val == T(0);
-        }
+        return Vec2(scale * (get_x() * cos_t - get_y() * sin_t), scale * (get_x() * sin_t + get_y() * cos_t));
     }
 
 private:
-    T x, y;
+    using super = vec_base::VecBase<Vec2<T>, 2, T>;
 };
 
 // Overload the multiplication operator for scalar multiplication.
-template <arithmetic T>
+template <vec_base::arithmetic T>
 [[nodiscard]] constexpr Vec2<T>
 operator*(T scalar, const Vec2<T> &vec) noexcept {
     return vec * scalar;
 }
 
 // Overload the output stream operator for Vec2.
-template <arithmetic T>
+template <vec_base::arithmetic T>
 std::ostream &
 operator<<(std::ostream &os, const Vec2<T> &vec) {
     os << "Vec2(" << vec.get_x() << ", " << vec.get_y() << ")";
@@ -178,143 +70,51 @@ operator<<(std::ostream &os, const Vec2<T> &vec) {
 }
 
 // Define a 2x2 matrix class using Vec2.
-template <arithmetic T>
-class Mat2 {
+template <vec_base::arithmetic T>
+class Mat2 : public vec_base::MatBase<Mat2<T>, Vec2<T>, 2, T> {
 public:
     // Constructors.
-    constexpr Mat2() noexcept : cols{Vec2<T>(T(1), T(0)), Vec2<T>(T(0), T(1))} {}
-    constexpr Mat2(const Vec2<T> &c0, const Vec2<T> &c1) noexcept : cols{c0, c1} {}
-    constexpr Mat2(T a11, T a12, T a21, T a22) noexcept : cols{Vec2<T>(a11, a21), Vec2<T>(a12, a22)} {}
-    constexpr Mat2(const Mat2<T> &other) noexcept = default;
-    constexpr Mat2(Mat2<T> &&other) noexcept = default;
+    constexpr Mat2() noexcept : super() {}
+    constexpr Mat2(const Vec2<T> &c0, const Vec2<T> &c1) noexcept : super(c0, c1) {}
+    constexpr Mat2(T a11, T a12, T a21, T a22) noexcept : super(Vec2<T>(a11, a21), Vec2<T>(a12, a22)) {}
+    constexpr Mat2(const Mat2 &other) noexcept = default;
+    constexpr Mat2(Mat2 &&other) noexcept = default;
 
     // Assignment operators.
-    constexpr Mat2 &operator=(const Mat2<T> &other) noexcept = default;
-    constexpr Mat2 &operator=(Mat2<T> &&other) noexcept = default;
-
-    // Matrix-vector multiplication.
-    [[nodiscard]] constexpr Vec2<T> operator*(const Vec2<T> &v) const noexcept {
-        return Vec2<T>(cols[0].get_x() * v.get_x() + cols[1].get_x() * v.get_y(),
-                       cols[0].get_y() * v.get_x() + cols[1].get_y() * v.get_y());
-    }
-
-    // Matrix-matrix multiplication.
-    [[nodiscard]] constexpr Mat2 operator*(const Mat2 &m) const noexcept {
-        return Mat2<T>((*this) * m.get_col(0), (*this) * m.get_col(1));
-    }
-
-    // Scalar multiplication.
-    [[nodiscard]] constexpr Mat2 operator*(T scalar) const noexcept {
-        return Mat2<T>(cols[0] * scalar, cols[1] * scalar);
-    }
-
-    // Getters.
-    [[nodiscard]] constexpr Vec2<T> get_col(int idx) const {
-        if (idx < 0 || idx >= 2) {
-            throw std::out_of_range("Invalid column index");
-        }
-        return cols[idx];
-    }
-
-    [[nodiscard]] constexpr Vec2<T> get_row(int idx) const {
-        switch (idx) {
-            case 0:
-                return Vec2<T>(cols[0].get_x(), cols[1].get_x());
-            case 1:
-                return Vec2<T>(cols[0].get_y(), cols[1].get_y());
-            default:
-                throw std::out_of_range("Invalid row index");
-        }
-    }
-
-    [[nodiscard]] constexpr T get_elem(int row, int col) const {
-        if (col < 0 || col >= 2 || row < 0 || row >= 2) {
-            throw std::out_of_range("Invalid matrix indices");
-        }
-        return row == 0 ? cols[col].get_x() : cols[col].get_y();
-    }
-
-    // Setters.
-    constexpr void set_col(int idx, const Vec2<T> &col) {
-        if (idx < 0 || idx >= 2) {
-            throw std::out_of_range("Invalid column index");
-        }
-        cols[idx] = col;
-    }
-
-    constexpr void set_row(int idx, const Vec2<T> &row) {
-        switch (idx) {
-            case 0:
-                cols[0].set_x(row.get_x());
-                cols[1].set_x(row.get_y());
-                break;
-            case 1:
-                cols[0].set_y(row.get_x());
-                cols[1].set_y(row.get_y());
-                break;
-            default:
-                throw std::out_of_range("Invalid row index");
-        }
-    }
-
-    constexpr void set_elem(int row, int col, T val) {
-        if (col < 0 || col >= 2 || row < 0 || row >= 2) {
-            throw std::out_of_range("Invalid matrix indices");
-        }
-        if (row == 0) {
-            cols[col].set_x(val);
-        } else {
-            cols[col].set_y(val);
-        }
-    }
-
-    // Transpose the matrix.
-    [[nodiscard]] constexpr Mat2 transpose() const noexcept {
-        return Mat2(Vec2<T>(cols[0].get_x(), cols[1].get_x()), 
-                   Vec2<T>(cols[0].get_y(), cols[1].get_y()));
-    }
+    constexpr Mat2 &operator=(const Mat2 &other) noexcept = default;
+    constexpr Mat2 &operator=(Mat2 &&other) noexcept = default;
 
     // Calculate the determinant.
-    // The determinant of a 2x2 matrix is calculated as:
-    // det(A) = a11 * a22 - a12 * a21
     [[nodiscard]] constexpr T determinant() const noexcept {
-        return cols[0].get_x() * cols[1].get_y() - cols[0].get_y() * cols[1].get_x();
+        return (*this)(0, 0) * (*this)(1, 1) - (*this)(1, 0) * (*this)(0, 1);
     }
 
     // Calculate the inverse of the matrix.
-    // The inverse of a 2x2 matrix is calculated as:
-    // A^-1 = (1/det(A)) * [[a22, -a12], [-a21, a11]]
-    [[nodiscard]] Mat2 inverse() const {
+    [[nodiscard]] constexpr Mat2 inverse() const {
         T det = determinant();
-        if (Vec2<T>::is_zero(det)) {
+        if (Vec2<T>::is_zero(det))
             throw std::runtime_error("Matrix is singular and cannot be inverted.");
-        }
 
         T inv_det = T{1} / det;
-        return Mat2(Vec2<T>(cols[1].get_y() * inv_det, -cols[0].get_y() * inv_det),
-                   Vec2<T>(-cols[1].get_x() * inv_det, cols[0].get_x() * inv_det));
+        return Mat2((*this)(1, 1), -(*this)(0, 1), -(*this)(1, 0), (*this)(0, 0)) * inv_det;
     }
 
     // Create rotation matrix.
-    [[nodiscard]] static Mat2 rotation(T theta) {
-        if constexpr (std::is_floating_point_v<T>) {
-            T cos_t = std::cos(theta);
-            T sin_t = std::sin(theta);
-            return Mat2(Vec2<T>(cos_t, sin_t), Vec2<T>(-sin_t, cos_t));
-        } else {
-            double cos_t = std::cos(static_cast<double>(theta));
-            double sin_t = std::sin(static_cast<double>(theta));
-            return Mat2(Vec2<T>(static_cast<T>(cos_t), static_cast<T>(sin_t)),
-                       Vec2<T>(static_cast<T>(-sin_t), static_cast<T>(cos_t)));
-        }
+    [[nodiscard]] static constexpr Mat2 rotation(T theta)
+        requires std::floating_point<T>
+    {
+        T cos_t = std::cos(theta);
+        T sin_t = std::sin(theta);
+        return Mat2(cos_t, -sin_t, sin_t, cos_t);
     }
 
 private:
-    std::array<Vec2<T>, 2> cols;
+    using super = vec_base::MatBase<Mat2<T>, Vec2<T>, 2, T>;
 };
 
 // Overload the multiplication operator for scalar multiplication of Mat2.
-template <arithmetic T>
-[[nodiscard]] constexpr Mat2<T> operator*(T scalar, const Mat2<T> &m) noexcept {
+template <vec_base::arithmetic T>
+[[nodiscard]] constexpr Mat2<T>
+operator*(T scalar, const Mat2<T> &m) noexcept {
     return m * scalar;
 }

--- a/dll_src/vector_2d.hpp
+++ b/dll_src/vector_2d.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <limits>
 #include <ostream>
@@ -8,63 +9,65 @@
 #include <type_traits>
 
 template <typename T>
+concept arithmetic = std::integral<T> || std::floating_point<T>;
+
+// Define a 2D vector class template.
+template <arithmetic T>
 class Vec2 {
 public:
-    // Constructor.
-    Vec2() : x(0), y(0) {}
-    Vec2(T x, T y) : x(x), y(y) {}
-    Vec2(const Vec2 &other) : x(other.x), y(other.y) {}
+    // Constructors.
+    constexpr Vec2() noexcept : x(T(0)), y(T(0)) {}
+    constexpr Vec2(T x, T y) noexcept : x(x), y(y) {}
+    constexpr Vec2(const Vec2 &other) noexcept = default;
+    constexpr Vec2(Vec2 &&other) noexcept = default;
 
-    // Overload operators.
-    Vec2 &operator=(const Vec2 &other) {
-        if (this != &other) {
-            x = other.x;
-            y = other.y;
-        }
-        return *this;
-    }
+    // Assignment operators.
+    constexpr Vec2 &operator=(const Vec2 &other) noexcept = default;
+    constexpr Vec2 &operator=(Vec2 &&other) noexcept = default;
 
-    Vec2 operator+(const Vec2 &other) const { return Vec2(x + other.x, y + other.y); }
+    // Operators.
+    [[nodiscard]] constexpr Vec2 operator+(const Vec2 &other) const noexcept { return Vec2(x + other.x, y + other.y); }
 
-    Vec2 operator-(const Vec2 &other) const { return Vec2(x - other.x, y - other.y); }
+    [[nodiscard]] constexpr Vec2 operator-(const Vec2 &other) const noexcept { return Vec2(x - other.x, y - other.y); }
 
-    Vec2 operator*(T scalar) const { return Vec2(x * scalar, y * scalar); }
+    [[nodiscard]] constexpr Vec2 operator*(T scalar) const noexcept { return Vec2(x * scalar, y * scalar); }
 
-    Vec2 operator/(T scalar) const {
-        if (is_zero(scalar))
+    [[nodiscard]] constexpr Vec2 operator/(T scalar) const {
+        if (is_zero(scalar)) {
             throw std::invalid_argument("Division by zero in Vec2.");
-
+        }
         return Vec2(x / scalar, y / scalar);
     }
 
-    Vec2 &operator+=(const Vec2 &other) {
+    // Compound assignment operators.
+    constexpr Vec2 &operator+=(const Vec2 &other) noexcept {
         x += other.x;
         y += other.y;
         return *this;
     }
 
-    Vec2 &operator-=(const Vec2 &other) {
+    constexpr Vec2 &operator-=(const Vec2 &other) noexcept {
         x -= other.x;
         y -= other.y;
         return *this;
     }
 
-    Vec2 &operator*=(T scalar) {
+    constexpr Vec2 &operator*=(T scalar) noexcept {
         x *= scalar;
         y *= scalar;
         return *this;
     }
 
-    Vec2 &operator/=(T scalar) {
-        if (is_zero(scalar))
+    constexpr Vec2 &operator/=(T scalar) {
+        if (is_zero(scalar)) {
             throw std::invalid_argument("Division by zero in Vec2.");
-
+        }
         x /= scalar;
         y /= scalar;
         return *this;
     }
 
-    bool operator==(const Vec2 &other) const {
+    [[nodiscard]] constexpr bool operator==(const Vec2 &other) const noexcept {
         if constexpr (std::is_floating_point_v<T>) {
             return std::abs(x - other.x) <= epsilon() && std::abs(y - other.y) <= epsilon();
         } else {
@@ -72,30 +75,31 @@ public:
         }
     }
 
-    bool operator!=(const Vec2 &other) const { return !(*this == other); }
+    [[nodiscard]] constexpr bool operator!=(const Vec2 &other) const noexcept { return !(*this == other); }
 
-    template <typename U>
-    explicit operator Vec2<U>() const {
+    template <arithmetic U>
+    [[nodiscard]] explicit constexpr operator Vec2<U>() const noexcept {
         return Vec2<U>(static_cast<U>(x), static_cast<U>(y));
     }
 
     // Getters.
-    T get_x() const { return x; }
-
-    T get_y() const { return y; }
+    [[nodiscard]] constexpr T get_x() const noexcept { return x; }
+    [[nodiscard]] constexpr T get_y() const noexcept { return y; }
 
     // Setters.
-    void set_x(T new_x) { x = new_x; }
-
-    void set_y(T new_y) { y = new_y; }
+    constexpr void set_x(T new_x) noexcept { x = new_x; }
+    constexpr void set_y(T new_y) noexcept { y = new_y; }
 
     // Norm calculation.
-    T norm(int ord = 2) const {
+    [[nodiscard]] T norm(int ord = 2) const {
         switch (ord) {
             case 1:
                 return std::abs(x) + std::abs(y);  // Manhattan norm (L1 norm)
             case 2:
-                return std::sqrt(x * x + y * y);  // Euclidean norm (L2 norm)
+                if constexpr (std::is_floating_point_v<T>)
+                    return std::sqrt(x * x + y * y);  // Euclidean norm (L2)
+                else
+                    return static_cast<T>(std::sqrt(static_cast<double>(x * x + y * y)));
             case -1:
                 return std::max(std::abs(x), std::abs(y));  // Maximum norm (L inf norm)
             default:
@@ -105,23 +109,39 @@ public:
 
     // Rotation function.
     // The rotation is performed around the origin (0, 0) using the standard 2D rotation matrix.
-    Vec2 rotate(T theta = T(0), T factor = T(1)) const {
+    [[nodiscard]] Vec2 rotate(T theta = T(0), T factor = T(1)) const {
         if (is_zero(theta))
             return Vec2(factor * x, factor * y);
 
-        T cos_t = std::cos(theta);
-        T sin_t = std::sin(theta);
-        return Vec2(factor * (x * cos_t - y * sin_t), factor * (x * sin_t + y * cos_t));
+        if constexpr (std::is_floating_point_v<T>) {
+            T cos_t = std::cos(theta);
+            T sin_t = std::sin(theta);
+            return Vec2(factor * (x * cos_t - y * sin_t), factor * (x * sin_t + y * cos_t));
+        } else {
+            double cos_t = std::cos(static_cast<double>(theta));
+            double sin_t = std::sin(static_cast<double>(theta));
+            double fx = static_cast<double>(factor * x);
+            double fy = static_cast<double>(factor * y);
+            return Vec2(static_cast<T>(fx * cos_t - fy * sin_t), static_cast<T>(fx * sin_t + fy * cos_t));
+        }
     }
 
     // Ceiling function.
-    Vec2 ceil() const { return Vec2(std::ceil(x), std::ceil(y)); }
+    [[nodiscard]] Vec2 ceil() const
+        requires std::is_floating_point_v<T>
+    {
+        return Vec2(std::ceil(x), std::ceil(y));
+    }
 
-private:
-    T x, y;
+    // Floor function.
+    [[nodiscard]] Vec2 floor() const
+        requires std::is_floating_point_v<T>
+    {
+        return Vec2(std::floor(x), std::floor(y));
+    }
 
     // epsilon value for floating-point comparison.
-    static constexpr T epsilon() {
+    [[nodiscard]] static constexpr T epsilon() noexcept {
         if constexpr (std::is_floating_point_v<T>) {
             return std::numeric_limits<T>::epsilon() * 1000;
         } else {
@@ -130,25 +150,171 @@ private:
     }
 
     // Check if the value is zero.
-    static bool is_zero(T value) {
+    [[nodiscard]] static constexpr bool is_zero(T val) noexcept {
         if constexpr (std::is_floating_point_v<T>) {
-            return std::abs(value) <= epsilon();
+            return std::abs(val) <= epsilon();
         } else {
-            return value == T(0);
+            return val == T(0);
         }
     }
+
+private:
+    T x, y;
 };
 
 // Overload the multiplication operator for scalar multiplication.
-template<typename T>
-Vec2<T> operator*(T scalar, const Vec2<T>& vec) {
+template <arithmetic T>
+[[nodiscard]] constexpr Vec2<T>
+operator*(T scalar, const Vec2<T> &vec) noexcept {
     return vec * scalar;
 }
 
 // Overload the output stream operator for Vec2.
-template <typename T>
+template <arithmetic T>
 std::ostream &
 operator<<(std::ostream &os, const Vec2<T> &vec) {
     os << "Vec2(" << vec.get_x() << ", " << vec.get_y() << ")";
     return os;
+}
+
+// Define a 2x2 matrix class using Vec2.
+template <arithmetic T>
+class Mat2 {
+public:
+    // Constructors.
+    constexpr Mat2() noexcept : cols{Vec2<T>(T(1), T(0)), Vec2<T>(T(0), T(1))} {}
+    constexpr Mat2(const Vec2<T> &c0, const Vec2<T> &c1) noexcept : cols{c0, c1} {}
+    constexpr Mat2(T a11, T a12, T a21, T a22) noexcept : cols{Vec2<T>(a11, a21), Vec2<T>(a12, a22)} {}
+    constexpr Mat2(const Mat2<T> &other) noexcept = default;
+    constexpr Mat2(Mat2<T> &&other) noexcept = default;
+
+    // Assignment operators.
+    constexpr Mat2 &operator=(const Mat2<T> &other) noexcept = default;
+    constexpr Mat2 &operator=(Mat2<T> &&other) noexcept = default;
+
+    // Matrix-vector multiplication.
+    [[nodiscard]] constexpr Vec2<T> operator*(const Vec2<T> &v) const noexcept {
+        return Vec2<T>(cols[0].get_x() * v.get_x() + cols[1].get_x() * v.get_y(),
+                       cols[0].get_y() * v.get_x() + cols[1].get_y() * v.get_y());
+    }
+
+    // Matrix-matrix multiplication.
+    [[nodiscard]] constexpr Mat2 operator*(const Mat2 &m) const noexcept {
+        return Mat2<T>((*this) * m.get_col(0), (*this) * m.get_col(1));
+    }
+
+    // Scalar multiplication.
+    [[nodiscard]] constexpr Mat2 operator*(T scalar) const noexcept {
+        return Mat2<T>(cols[0] * scalar, cols[1] * scalar);
+    }
+
+    // Getters.
+    [[nodiscard]] constexpr Vec2<T> get_col(int idx) const {
+        if (idx < 0 || idx >= 2) {
+            throw std::out_of_range("Invalid column index");
+        }
+        return cols[idx];
+    }
+
+    [[nodiscard]] constexpr Vec2<T> get_row(int idx) const {
+        switch (idx) {
+            case 0:
+                return Vec2<T>(cols[0].get_x(), cols[1].get_x());
+            case 1:
+                return Vec2<T>(cols[0].get_y(), cols[1].get_y());
+            default:
+                throw std::out_of_range("Invalid row index");
+        }
+    }
+
+    [[nodiscard]] constexpr T get_elem(int row, int col) const {
+        if (col < 0 || col >= 2 || row < 0 || row >= 2) {
+            throw std::out_of_range("Invalid matrix indices");
+        }
+        return row == 0 ? cols[col].get_x() : cols[col].get_y();
+    }
+
+    // Setters.
+    constexpr void set_col(int idx, const Vec2<T> &col) {
+        if (idx < 0 || idx >= 2) {
+            throw std::out_of_range("Invalid column index");
+        }
+        cols[idx] = col;
+    }
+
+    constexpr void set_row(int idx, const Vec2<T> &row) {
+        switch (idx) {
+            case 0:
+                cols[0].set_x(row.get_x());
+                cols[1].set_x(row.get_y());
+                break;
+            case 1:
+                cols[0].set_y(row.get_x());
+                cols[1].set_y(row.get_y());
+                break;
+            default:
+                throw std::out_of_range("Invalid row index");
+        }
+    }
+
+    constexpr void set_elem(int row, int col, T val) {
+        if (col < 0 || col >= 2 || row < 0 || row >= 2) {
+            throw std::out_of_range("Invalid matrix indices");
+        }
+        if (row == 0) {
+            cols[col].set_x(val);
+        } else {
+            cols[col].set_y(val);
+        }
+    }
+
+    // Transpose the matrix.
+    [[nodiscard]] constexpr Mat2 transpose() const noexcept {
+        return Mat2(Vec2<T>(cols[0].get_x(), cols[1].get_x()), 
+                   Vec2<T>(cols[0].get_y(), cols[1].get_y()));
+    }
+
+    // Calculate the determinant.
+    // The determinant of a 2x2 matrix is calculated as:
+    // det(A) = a11 * a22 - a12 * a21
+    [[nodiscard]] constexpr T determinant() const noexcept {
+        return cols[0].get_x() * cols[1].get_y() - cols[0].get_y() * cols[1].get_x();
+    }
+
+    // Calculate the inverse of the matrix.
+    // The inverse of a 2x2 matrix is calculated as:
+    // A^-1 = (1/det(A)) * [[a22, -a12], [-a21, a11]]
+    [[nodiscard]] Mat2 inverse() const {
+        T det = determinant();
+        if (Vec2<T>::is_zero(det)) {
+            throw std::runtime_error("Matrix is singular and cannot be inverted.");
+        }
+
+        T inv_det = T{1} / det;
+        return Mat2(Vec2<T>(cols[1].get_y() * inv_det, -cols[0].get_y() * inv_det),
+                   Vec2<T>(-cols[1].get_x() * inv_det, cols[0].get_x() * inv_det));
+    }
+
+    // Create rotation matrix.
+    [[nodiscard]] static Mat2 rotation(T theta) {
+        if constexpr (std::is_floating_point_v<T>) {
+            T cos_t = std::cos(theta);
+            T sin_t = std::sin(theta);
+            return Mat2(Vec2<T>(cos_t, sin_t), Vec2<T>(-sin_t, cos_t));
+        } else {
+            double cos_t = std::cos(static_cast<double>(theta));
+            double sin_t = std::sin(static_cast<double>(theta));
+            return Mat2(Vec2<T>(static_cast<T>(cos_t), static_cast<T>(sin_t)),
+                       Vec2<T>(static_cast<T>(-sin_t), static_cast<T>(cos_t)));
+        }
+    }
+
+private:
+    std::array<Vec2<T>, 2> cols;
+};
+
+// Overload the multiplication operator for scalar multiplication of Mat2.
+template <arithmetic T>
+[[nodiscard]] constexpr Mat2<T> operator*(T scalar, const Mat2<T> &m) noexcept {
+    return m * scalar;
 }

--- a/dll_src/vector_2d.hpp
+++ b/dll_src/vector_2d.hpp
@@ -8,12 +8,12 @@
 #include "vector_base.hpp"
 
 // Define a 2D vector class template.
-template <vec_base::arithmetic T>
+template <vec_base::Arithmetic T>
 class Vec2 : public vec_base::VecBase<Vec2<T>, 2, T> {
 public:
     // Constructors.
-    constexpr Vec2() noexcept : super() {}
-    constexpr Vec2(T x, T y) noexcept : super(x, y) {}
+    constexpr Vec2() noexcept : Super() {}
+    constexpr Vec2(T x, T y) noexcept : Super(x, y) {}
     constexpr Vec2(const Vec2 &other) noexcept = default;
     constexpr Vec2(Vec2 &&other) noexcept = default;
 
@@ -22,7 +22,7 @@ public:
     constexpr Vec2 &operator=(Vec2 &&other) noexcept = default;
 
     // Type conversion operator.
-    template <vec_base::arithmetic U>
+    template <vec_base::Arithmetic U>
     [[nodiscard]] explicit constexpr operator Vec2<U>() const noexcept {
         return Vec2<U>(static_cast<U>(get_x()), static_cast<U>(get_y()));
     }
@@ -49,18 +49,18 @@ public:
     }
 
 private:
-    using super = vec_base::VecBase<Vec2<T>, 2, T>;
+    using Super = vec_base::VecBase<Vec2<T>, 2, T>;
 };
 
 // Overload the multiplication operator for scalar multiplication.
-template <vec_base::arithmetic T>
+template <vec_base::Arithmetic T>
 [[nodiscard]] constexpr Vec2<T>
 operator*(T scalar, const Vec2<T> &vec) noexcept {
     return vec * scalar;
 }
 
 // Overload the output stream operator for Vec2.
-template <vec_base::arithmetic T>
+template <vec_base::Arithmetic T>
 std::ostream &
 operator<<(std::ostream &os, const Vec2<T> &vec) {
     os << "Vec2(" << vec.get_x() << ", " << vec.get_y() << ")";
@@ -68,13 +68,13 @@ operator<<(std::ostream &os, const Vec2<T> &vec) {
 }
 
 // Define a 2x2 matrix class using Vec2.
-template <vec_base::arithmetic T>
+template <vec_base::Arithmetic T>
 class Mat2 : public vec_base::MatBase<Mat2<T>, Vec2<T>, 2, T> {
 public:
     // Constructors.
-    constexpr Mat2() noexcept : super() {}
-    constexpr Mat2(const Vec2<T> &c0, const Vec2<T> &c1) noexcept : super(c0, c1) {}
-    constexpr Mat2(T a11, T a12, T a21, T a22) noexcept : super(Vec2<T>(a11, a21), Vec2<T>(a12, a22)) {}
+    constexpr Mat2() noexcept : Super() {}
+    constexpr Mat2(const Vec2<T> &c0, const Vec2<T> &c1) noexcept : Super(c0, c1) {}
+    constexpr Mat2(T a11, T a12, T a21, T a22) noexcept : Super(Vec2<T>(a11, a21), Vec2<T>(a12, a22)) {}
     constexpr Mat2(const Mat2 &other) noexcept = default;
     constexpr Mat2(Mat2 &&other) noexcept = default;
 
@@ -110,11 +110,11 @@ public:
     }
 
 private:
-    using super = vec_base::MatBase<Mat2<T>, Vec2<T>, 2, T>;
+    using Super = vec_base::MatBase<Mat2<T>, Vec2<T>, 2, T>;
 };
 
 // Overload the multiplication operator for scalar multiplication of Mat2.
-template <vec_base::arithmetic T>
+template <vec_base::Arithmetic T>
 [[nodiscard]] constexpr Mat2<T>
 operator*(T scalar, const Mat2<T> &m) noexcept {
     return m * scalar;

--- a/dll_src/vector_2d.hpp
+++ b/dll_src/vector_2d.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <array>
 #include <cmath>
 #include <concepts>
 #include <ostream>
@@ -46,7 +45,6 @@ public:
 
         T cos_t = std::cos(theta);
         T sin_t = std::sin(theta);
-
         return Vec2(scale * (get_x() * cos_t - get_y() * sin_t), scale * (get_x() * sin_t + get_y() * cos_t));
     }
 
@@ -99,13 +97,16 @@ public:
         return Mat2((*this)(1, 1), -(*this)(0, 1), -(*this)(1, 0), (*this)(0, 0)) * inv_det;
     }
 
+    // Create identity matrix.
+    [[nodiscard]] static constexpr Mat2 identity() { return Mat2(T{1}, T{0}, T{0}, T{1}); }
+
     // Create rotation matrix.
-    [[nodiscard]] static constexpr Mat2 rotation(T theta)
+    [[nodiscard]] static constexpr Mat2 rotation(T theta, T scale = T{1})
         requires std::floating_point<T>
     {
-        T cos_t = std::cos(theta);
-        T sin_t = std::sin(theta);
-        return Mat2(cos_t, -sin_t, sin_t, cos_t);
+        T c = std::cos(theta) * scale;
+        T s = std::sin(theta) * scale;
+        return Mat2(c, -s, s, c);
     }
 
 private:

--- a/dll_src/vector_3d.hpp
+++ b/dll_src/vector_3d.hpp
@@ -2,13 +2,13 @@
 
 #include "vector_2d.hpp"
 
-template <vec_base::arithmetic T>
+template <vec_base::Arithmetic T>
 class Vec3 : public vec_base::VecBase<Vec3<T>, 3, T> {
 public:
     // Constructors.
-    constexpr Vec3() noexcept : super() {}
-    constexpr Vec3(T x, T y, T z) noexcept : super(x, y, z) {}
-    explicit constexpr Vec3(const Vec2<T> &vec, T z = T{0}) noexcept : super(vec[0], vec[1], z) {}
+    constexpr Vec3() noexcept : Super() {}
+    constexpr Vec3(T x, T y, T z) noexcept : Super(x, y, z) {}
+    explicit constexpr Vec3(const Vec2<T> &vec, T z = T{0}) noexcept : Super(vec[0], vec[1], z) {}
     constexpr Vec3(const Vec3 &other) noexcept = default;
     constexpr Vec3(Vec3 &&other) noexcept = default;
 
@@ -17,49 +17,57 @@ public:
     constexpr Vec3 &operator=(Vec3 &&other) noexcept = default;
 
     // Type conversion operator.
-    template <vec_base::arithmetic U>
+    template <vec_base::Arithmetic U>
     [[nodiscard]] explicit constexpr operator Vec3<U>() const noexcept {
         return Vec3<U>(static_cast<U>(get_x()), static_cast<U>(get_y()), static_cast<U>(get_z()));
     }
 
     // Getters.
-    [[nodiscard]] constexpr T get_x() const noexcept { return this->data[0]; }
-    [[nodiscard]] constexpr T get_y() const noexcept { return this->data[1]; }
-    [[nodiscard]] constexpr T get_z() const noexcept { return this->data[2]; }
+    [[nodiscard]] constexpr const T &get_x() const noexcept { return this->data[0]; }
+    [[nodiscard]] constexpr const T &get_y() const noexcept { return this->data[1]; }
+    [[nodiscard]] constexpr const T &get_z() const noexcept { return this->data[2]; }
 
     // Setters.
     constexpr void set_x(T new_x) noexcept { this->data[0] = new_x; }
     constexpr void set_y(T new_y) noexcept { this->data[1] = new_y; }
     constexpr void set_z(T new_z) noexcept { this->data[2] = new_z; }
 
+    // Converters.
+    [[nodiscard]] constexpr Vec2<T> to_vec2() const noexcept { return Vec2<T>(this->data[0], this->data[1]); }
+
 private:
-    using super = vec_base::VecBase<Vec3<T>, 3, T>;
+    using Super = vec_base::VecBase<Vec3<T>, 3, T>;
 };
 
 // Overload the multiplication operator for scalar multiplication.
-template <vec_base::arithmetic T>
+template <vec_base::Arithmetic T>
 [[nodiscard]] constexpr Vec3<T>
 operator*(T scalar, const Vec3<T> &vec) noexcept {
     return vec * scalar;
 }
 
-template <vec_base::arithmetic T>
+template <vec_base::Arithmetic T>
 class Mat3 : public vec_base::MatBase<Mat3<T>, Vec3<T>, 3, T> {
 public:
     // Constructors.
-    constexpr Mat3() noexcept : super() {}
-    constexpr Mat3(const Vec3<T> &c0, const Vec3<T> &c1, const Vec3<T> &c2) noexcept : super(c0, c1, c2) {}
+    constexpr Mat3() noexcept : Super() {}
+    constexpr Mat3(const Vec3<T> &c0, const Vec3<T> &c1, const Vec3<T> &c2) noexcept : Super(c0, c1, c2) {}
     constexpr explicit Mat3(const Mat2<T> &m2) noexcept :
-        super(Vec3<T>(m2[0]), Vec3<T>(m2[1]), Vec3<T>(T{0}, T{0}, T{1})) {}
-    constexpr Mat3(const Mat2<T> &m2, const Vec3<T> &c2) noexcept : super(Vec3<T>(m2[0]), Vec3<T>(m2[1]), c2) {}
+        Super(Vec3<T>(m2[0]), Vec3<T>(m2[1]), Vec3<T>(T{0}, T{0}, T{1})) {}
+    constexpr Mat3(const Mat2<T> &m2, const Vec3<T> &c2) noexcept : Super(Vec3<T>(m2[0]), Vec3<T>(m2[1]), c2) {}
     constexpr Mat3(T a11, T a12, T a13, T a21, T a22, T a23, T a31, T a32, T a33) noexcept :
-        super(Vec3<T>(a11, a21, a31), Vec3<T>(a12, a22, a32), Vec3<T>(a13, a23, a33)) {}
+        Super(Vec3<T>(a11, a21, a31), Vec3<T>(a12, a22, a32), Vec3<T>(a13, a23, a33)) {}
     constexpr Mat3(const Mat3 &other) noexcept = default;
     constexpr Mat3(Mat3 &&other) noexcept = default;
 
     // Assignment operators.
     constexpr Mat3 &operator=(const Mat3 &other) noexcept = default;
     constexpr Mat3 &operator=(Mat3 &&other) noexcept = default;
+
+    // Converters.
+    [[nodiscard]] constexpr Mat2<T> to_mat2() const noexcept {
+        return Mat2<T>(this->cols[0].to_vec2(), this->cols[1].to_vec2());
+    }
 
     // Create identity matrix.
     [[nodiscard]] static constexpr Mat3 identity() {
@@ -86,11 +94,11 @@ public:
     }
 
 private:
-    using super = vec_base::MatBase<Mat3<T>, Vec3<T>, 3, T>;
+    using Super = vec_base::MatBase<Mat3<T>, Vec3<T>, 3, T>;
 };
 
 // Overload the multiplication operator for scalar multiplication of Mat3.
-template <vec_base::arithmetic T>
+template <vec_base::Arithmetic T>
 [[nodiscard]] constexpr Mat3<T>
 operator*(T scalar, const Mat3<T> &m) noexcept {
     return m * scalar;

--- a/dll_src/vector_3d.hpp
+++ b/dll_src/vector_3d.hpp
@@ -83,7 +83,7 @@ public:
     }
 
     // Create rotation matrix.
-    [[nodiscard]] static constexpr Mat3 rotation(T theta, int axis = 2, T scale = T{1})
+    [[nodiscard]] static constexpr Mat3 rotation(T theta, T scale = T{1}, int axis = 2)
         requires std::floating_point<T>
     {
         T c = std::cos(theta) * scale;

--- a/dll_src/vector_3d.hpp
+++ b/dll_src/vector_3d.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <array>
+#include <stdexcept>
+
+#include "vector_2d.hpp"
+#include "vector_base.hpp"
+
+template <vec_base::arithmetic T>
+class Vec3 : public vec_base::VecBase<Vec3<T>, 3, T> {
+public:
+    // Constructors.
+    constexpr Vec3() noexcept : super() {}
+    constexpr Vec3(T x, T y, T z) noexcept : super(x, y, z) {}
+    explicit constexpr Vec3(const Vec2<T> &vec, T z = T{0}) noexcept : super(vec[0], vec[1], z) {}
+    constexpr Vec3(const Vec3 &other) noexcept = default;
+    constexpr Vec3(Vec3 &&other) noexcept = default;
+
+    // Assignment operators.
+    constexpr Vec3 &operator=(const Vec3 &other) noexcept = default;
+    constexpr Vec3 &operator=(Vec3 &&other) noexcept = default;
+
+    // Type conversion operator.
+    template <vec_base::arithmetic U>
+    [[nodiscard]] explicit constexpr operator Vec3<U>() const noexcept {
+        return Vec3<U>(static_cast<U>(get_x()), static_cast<U>(get_y()), static_cast<U>(get_z()));
+    }
+
+    // Getters.
+    [[nodiscard]] constexpr T get_x() const noexcept { return this->data[0]; }
+    [[nodiscard]] constexpr T get_y() const noexcept { return this->data[1]; }
+    [[nodiscard]] constexpr T get_z() const noexcept { return this->data[2]; }
+
+    // Setters.
+    constexpr void set_x(T new_x) noexcept { this->data[0] = new_x; }
+    constexpr void set_y(T new_y) noexcept { this->data[1] = new_y; }
+    constexpr void set_z(T new_z) noexcept { this->data[2] = new_y; }
+
+private:
+    using super = vec_base::VecBase<Vec3<T>, 3, T>;
+};
+
+// Overload the multiplication operator for scalar multiplication.
+template <vec_base::arithmetic T>
+[[nodiscard]] constexpr Vec3<T>
+operator*(T scalar, const Vec3<T> &vec) noexcept {
+    return vec * scalar;
+}
+
+template <vec_base::arithmetic T>
+class Mat3 : public vec_base::MatBase<Mat3<T>, Vec3<T>, 3, T> {
+public:
+    // Constructors.
+    constexpr Mat3() noexcept : super() {}
+    constexpr Mat3(const Vec3<T> &c0, const Vec3<T> &c1, const Vec3<T> &c2) noexcept : super(c0, c1, c2) {}
+    constexpr explicit Mat3(const Mat2<T> &m2) noexcept :
+        super(Vec3<T>(m2[0]), Vec3<T>(m2[1]), Vec3<T>(T{0}, T{0}, T{1})) {}
+    constexpr Mat3(const Mat2<T> &m2, const Vec3<T> &c2) noexcept : super(Vec3<T>(m2[0]), Vec3<T>(m2[1]), c2) {}
+    constexpr Mat3(T a11, T a12, T a13, T a21, T a22, T a23, T a31, T a32, T a33) noexcept :
+        super(Vec3<T>(a11, a21, a31), Vec3<T>(a12, a22, a32), Vec3<T>(a13, a23, a33)) {}
+    constexpr Mat3(const Mat3 &other) noexcept = default;
+    constexpr Mat3(Mat3 &&other) noexcept = default;
+
+    // Assignment operators.
+    constexpr Mat3 &operator=(const Mat3 &other) noexcept = default;
+    constexpr Mat3 &operator=(Mat3 &&other) noexcept = default;
+
+private:
+    using super = vec_base::MatBase<Mat3<T>, Vec3<T>, 3, T>;
+};
+
+// Overload the multiplication operator for scalar multiplication of Mat3.
+template <vec_base::arithmetic T>
+[[nodiscard]] constexpr Mat3<T>
+operator*(T scalar, const Mat3<T> &m) noexcept {
+    return m * scalar;
+}

--- a/dll_src/vector_3d.hpp
+++ b/dll_src/vector_3d.hpp
@@ -1,10 +1,6 @@
 #pragma once
 
-#include <array>
-#include <stdexcept>
-
 #include "vector_2d.hpp"
-#include "vector_base.hpp"
 
 template <vec_base::arithmetic T>
 class Vec3 : public vec_base::VecBase<Vec3<T>, 3, T> {
@@ -34,7 +30,7 @@ public:
     // Setters.
     constexpr void set_x(T new_x) noexcept { this->data[0] = new_x; }
     constexpr void set_y(T new_y) noexcept { this->data[1] = new_y; }
-    constexpr void set_z(T new_z) noexcept { this->data[2] = new_y; }
+    constexpr void set_z(T new_z) noexcept { this->data[2] = new_z; }
 
 private:
     using super = vec_base::VecBase<Vec3<T>, 3, T>;
@@ -64,6 +60,30 @@ public:
     // Assignment operators.
     constexpr Mat3 &operator=(const Mat3 &other) noexcept = default;
     constexpr Mat3 &operator=(Mat3 &&other) noexcept = default;
+
+    // Create identity matrix.
+    [[nodiscard]] static constexpr Mat3 identity() {
+        return Mat3(T{1}, T{0}, T{0}, T{0}, T{1}, T{0}, T{0}, T{0}, T{1});
+    }
+
+    // Create rotation matrix.
+    [[nodiscard]] static constexpr Mat3 rotation(T theta, int axis = 2, T scale = T{1})
+        requires std::floating_point<T>
+    {
+        T c = std::cos(theta) * scale;
+        T s = std::sin(theta) * scale;
+
+        switch (axis) {
+            case 0:
+                return Mat3(T{1}, T{0}, T{0}, T{0}, c, -s, T{0}, s, c);
+            case 1:
+                return Mat3(c, T{0}, s, T{0}, T{1}, T{0}, -s, T{0}, c);
+            case 2:
+                return Mat3(c, -s, T{0}, s, c, T{0}, T{0}, T{0}, T{1});
+            default:
+                throw std::invalid_argument("Unsupported axis.");
+        }
+    }
 
 private:
     using super = vec_base::MatBase<Mat3<T>, Vec3<T>, 3, T>;

--- a/dll_src/vector_3d.hpp
+++ b/dll_src/vector_3d.hpp
@@ -46,6 +46,14 @@ operator*(T scalar, const Vec3<T> &vec) noexcept {
     return vec * scalar;
 }
 
+// Overload the output stream operator for Vec3.
+template <vec_base::Arithmetic T>
+std::ostream &
+operator<<(std::ostream &os, const Vec3<T> &vec) {
+    os << "Vec3(" << vec.get_x() << ", " << vec.get_y() << ", " << vec.get_z() << ")";
+    return os;
+}
+
 template <vec_base::Arithmetic T>
 class Mat3 : public vec_base::MatBase<Mat3<T>, Vec3<T>, 3, T> {
 public:

--- a/dll_src/vector_base.hpp
+++ b/dll_src/vector_base.hpp
@@ -364,8 +364,19 @@ public:
     // Transpose the matrix.
     [[nodiscard]] constexpr Derived transpose() const noexcept {
         Derived result;
-        for (std::size_t j = 0; j < N; ++j)
-            for (std::size_t i = 0; i < N; ++i) result(j, i) = (*this)(i, j);
+        for (std::size_t j = 0; j < N; ++j) {
+            for (std::size_t i = 0; i < N; ++i) {
+                result(j, i) = (*this)(i, j);
+            }
+        }
+        return result;
+    }
+
+    [[nodiscard]] constexpr Derived abs() const noexcept {
+        Derived result;
+        for (std::size_t i = 0; i < N; ++i) {
+            result[i] = cols[i].abs();
+        }
         return result;
     }
 

--- a/dll_src/vector_base.hpp
+++ b/dll_src/vector_base.hpp
@@ -11,15 +11,15 @@
 
 namespace vec_base {
 template <typename T>
-concept arithmetic = std::integral<T> || std::floating_point<T>;
+concept Arithmetic = std::integral<T> || std::floating_point<T>;
 
 // Vector class.
-template <typename Derived, std::size_t N, arithmetic T>
+template <typename Derived, std::size_t N, Arithmetic T>
     requires(N > 0)
 class VecBase {
 public:
-    using iterator = typename std::array<T, N>::iterator;
-    using const_iterator = typename std::array<T, N>::const_iterator;
+    using Iterator = typename std::array<T, N>::iterator;
+    using ConstIterator = typename std::array<T, N>::const_iterator;
 
     // Constructors.
     constexpr VecBase() = default;
@@ -33,12 +33,12 @@ public:
     [[nodiscard]] constexpr const T &operator[](std::size_t i) const noexcept { return data[i]; }
 
     // Iterator support.
-    [[nodiscard]] constexpr iterator begin() noexcept { return data.begin(); }
-    [[nodiscard]] constexpr const_iterator begin() const noexcept { return data.begin(); }
-    [[nodiscard]] constexpr const_iterator cbegin() const noexcept { return data.cbegin(); }
-    [[nodiscard]] constexpr iterator end() noexcept { return data.end(); }
-    [[nodiscard]] constexpr const_iterator end() const noexcept { return data.end(); }
-    [[nodiscard]] constexpr const_iterator cend() const noexcept { return data.cend(); }
+    [[nodiscard]] constexpr Iterator begin() noexcept { return data.begin(); }
+    [[nodiscard]] constexpr ConstIterator begin() const noexcept { return data.begin(); }
+    [[nodiscard]] constexpr ConstIterator cbegin() const noexcept { return data.cbegin(); }
+    [[nodiscard]] constexpr Iterator end() noexcept { return data.end(); }
+    [[nodiscard]] constexpr ConstIterator end() const noexcept { return data.end(); }
+    [[nodiscard]] constexpr ConstIterator cend() const noexcept { return data.cend(); }
 
     // Size and capacity.
     [[nodiscard]] static constexpr std::size_t size() noexcept { return N; }
@@ -176,9 +176,6 @@ public:
         return result;
     }
 
-    // Data access.
-    [[nodiscard]] constexpr const std::array<T, N> &raw_data() const noexcept { return data; }
-
     // Helper functions.
     [[nodiscard]] static constexpr bool is_zero(const T &val) noexcept {
         if constexpr (std::is_floating_point_v<T>) {
@@ -222,7 +219,7 @@ protected:
 };
 
 // Square matrix class.
-template <typename Derived, typename VecType, std::size_t N, arithmetic T>
+template <typename Derived, typename VecType, std::size_t N, Arithmetic T>
     requires(N > 0) && (VecType::size() == N)
 class MatBase {
 public:

--- a/dll_src/vector_base.hpp
+++ b/dll_src/vector_base.hpp
@@ -348,11 +348,24 @@ public:
     }
 
     // Setters.
-    constexpr void set_elem(std::size_t row, std::size_t col, T val) noexcept { (*this)(col, row) = val; }
+    constexpr void set_elem(std::size_t row, std::size_t col, T val) {
+        if (col >= N || row >= VecType::size())
+            throw std::out_of_range("Mat element indices out of range.");
 
-    constexpr void set_col(std::size_t idx, const VecType &col) noexcept { cols[idx] = col; }
+        (*this)(col, row) = val;
+    }
 
-    constexpr void set_row(std::size_t idx, const VecType &row) noexcept {
+    constexpr void set_col(std::size_t idx, const VecType &col) {
+        if (idx >= N)
+            throw std::out_of_range("Mat column index out of range.");
+
+        cols[idx] = col;
+    }
+
+    constexpr void set_row(std::size_t idx, const VecType &row) {
+        if (idx >= VecType::size())
+            throw std::out_of_range("Mat row index out of range.");
+
         for (std::size_t j = 0; j < N; ++j) {
             (*this)(j, idx) = row[j];
         }

--- a/dll_src/vector_base.hpp
+++ b/dll_src/vector_base.hpp
@@ -1,0 +1,379 @@
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <concepts>
+#include <cstddef>
+#include <limits>
+#include <ranges>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+namespace vec_base {
+template <typename T>
+concept arithmetic = std::integral<T> || std::floating_point<T>;
+
+// Vector class.
+template <typename Derived, std::size_t N, arithmetic T>
+    requires(N > 0)
+class VecBase {
+public:
+    using iterator = typename std::array<T, N>::iterator;
+    using const_iterator = typename std::array<T, N>::const_iterator;
+
+    // Constructors.
+    constexpr VecBase() = default;
+    template <typename... Args>
+    constexpr VecBase(Args &&...args) noexcept
+        requires(sizeof...(Args) == N && (std::is_same_v<T, std::decay_t<Args>> && ...))
+        : data{std::forward<Args>(args)...} {}
+
+    // Element access.
+    [[nodiscard]] constexpr T &operator[](std::size_t i) noexcept { return data[i]; }
+    [[nodiscard]] constexpr const T &operator[](std::size_t i) const noexcept { return data[i]; }
+
+    // Iterator support.
+    [[nodiscard]] constexpr iterator begin() noexcept { return data.begin(); }
+    [[nodiscard]] constexpr const_iterator begin() const noexcept { return data.begin(); }
+    [[nodiscard]] constexpr const_iterator cbegin() const noexcept { return data.cbegin(); }
+    [[nodiscard]] constexpr iterator end() noexcept { return data.end(); }
+    [[nodiscard]] constexpr const_iterator end() const noexcept { return data.end(); }
+    [[nodiscard]] constexpr const_iterator cend() const noexcept { return data.cend(); }
+
+    // Size and capacity.
+    [[nodiscard]] static constexpr std::size_t size() noexcept { return N; }
+
+    // Assignment operators (return Derived&).
+    constexpr Derived &operator+=(const Derived &other) noexcept {
+        for (std::size_t i = 0; i < N; ++i) {
+            data[i] += other[i];
+        }
+        return derived();
+    }
+    constexpr Derived &operator-=(const Derived &other) noexcept {
+        for (std::size_t i = 0; i < N; ++i) {
+            data[i] -= other[i];
+        }
+        return derived();
+    }
+    constexpr Derived &operator*=(const T &scalar) noexcept {
+        for (auto &elem : data) {
+            elem *= scalar;
+        }
+        return derived();
+    }
+    constexpr Derived &operator/=(const T &scalar) {
+        if (is_zero(scalar))
+            throw std::invalid_argument("Division by zero in Vec.");
+
+        for (auto &elem : data) {
+            elem /= scalar;
+        }
+        return derived();
+    }
+
+    // Arithmetic operators (return Derived).
+    [[nodiscard]] constexpr Derived operator+(const Derived &other) const noexcept {
+        Derived result = derived();
+        result += other;
+        return result;
+    }
+    [[nodiscard]] constexpr Derived operator-(const Derived &other) const noexcept {
+        Derived result = derived();
+        result -= other;
+        return result;
+    }
+    [[nodiscard]] constexpr Derived operator*(const T &scalar) const noexcept {
+        Derived result = derived();
+        result *= scalar;
+        return result;
+    }
+    [[nodiscard]] constexpr Derived operator/(const T &scalar) const {
+        Derived result = derived();
+        result /= scalar;
+        return result;
+    }
+
+    // Unary operators.
+    [[nodiscard]] constexpr Derived operator-() const noexcept {
+        Derived result;
+        for (std::size_t i = 0; i < N; ++i) {
+            result[i] = -data[i];
+        }
+        return result;
+    }
+
+    // Comparison operators.
+    [[nodiscard]] constexpr bool operator==(const Derived &other) const noexcept {
+        return std::ranges::equal(data, other.data, [](const T &a, const T &b) { return are_equal(a, b); });
+    }
+
+    [[nodiscard]] constexpr bool operator!=(const Derived &other) const noexcept { return !(*this == other); }
+
+    // Mathematical operations.
+    [[nodiscard]] constexpr T norm(int ord = 2) const {
+        switch (ord) {
+            case 1: {
+                T sum = T{0};
+                for (const auto &val : data) {
+                    sum += std::abs(val);
+                }
+                return sum;
+            }
+            case 2: {
+                T sum = T{0};
+                for (const auto &val : data) {
+                    sum += val * val;
+                }
+                return calc_sqrt(sum);
+            }
+            case -1: {
+                T max_val = T{};
+                for (const auto &val : data) {
+                    max_val = std::max(max_val, std::abs(val));
+                }
+                return max_val;
+            }
+            default:
+                throw std::invalid_argument("Unsupported norm order.");
+        }
+    }
+
+    [[nodiscard]] constexpr T dot(const Derived &other) const noexcept {
+        T result = T{};
+        for (std::size_t i = 0; i < N; ++i) {
+            result += data[i] * other[i];
+        }
+        return result;
+    }
+
+    // Element-wise functions.
+    [[nodiscard]] constexpr Derived ceil() const noexcept
+        requires std::floating_point<T>
+    {
+        Derived result;
+        for (std::size_t i = 0; i < N; ++i) {
+            result[i] = std::ceil(data[i]);
+        }
+        return result;
+    }
+
+    [[nodiscard]] constexpr Derived floor() const noexcept
+        requires std::floating_point<T>
+    {
+        Derived result;
+        for (std::size_t i = 0; i < N; ++i) {
+            result[i] = std::floor(data[i]);
+        }
+        return result;
+    }
+
+    [[nodiscard]] constexpr Derived abs() const noexcept {
+        Derived result;
+        for (std::size_t i = 0; i < N; ++i) {
+            result[i] = std::abs(data[i]);
+        }
+        return result;
+    }
+
+    // Data access.
+    [[nodiscard]] constexpr const std::array<T, N> &raw_data() const noexcept { return data; }
+
+    // Helper functions.
+    [[nodiscard]] static constexpr bool is_zero(const T &val) noexcept {
+        if constexpr (std::is_floating_point_v<T>) {
+            return std::abs(val) <= epsilon();
+        } else {
+            return val == T{0};
+        }
+    }
+
+    [[nodiscard]] static constexpr bool are_equal(const T &a, const T &b) noexcept {
+        if constexpr (std::is_floating_point_v<T>) {
+            return std::abs(a - b) <= epsilon();
+        } else {
+            return a == b;
+        }
+    }
+
+protected:
+    std::array<T, N> data{};
+
+    // CRTP helper to get derived instance.
+    [[nodiscard]] constexpr Derived &derived() noexcept { return static_cast<Derived &>(*this); }
+    [[nodiscard]] constexpr const Derived &derived() const noexcept { return static_cast<const Derived &>(*this); }
+
+    // Helper functions.
+    [[nodiscard]] static constexpr T epsilon() noexcept {
+        if constexpr (std::is_floating_point_v<T>) {
+            return std::numeric_limits<T>::epsilon() * T{1000};
+        } else {
+            return T{0};
+        }
+    }
+
+    [[nodiscard]] static constexpr T calc_sqrt(const T &value) {
+        if constexpr (std::is_floating_point_v<T>) {
+            return std::sqrt(value);
+        } else {
+            return static_cast<T>(std::sqrt(static_cast<double>(value)));
+        }
+    }
+};
+
+// Square matrix class.
+template <typename Derived, typename VecType, std::size_t N, arithmetic T>
+    requires(N > 0) && (VecType::size() == N)
+class MatBase {
+public:
+    // Constructors.
+    constexpr MatBase() = default;
+    template <typename... Args>
+    constexpr MatBase(Args &&...args) noexcept
+        requires(sizeof...(Args) == N && (std::is_same_v<VecType, std::decay_t<Args>> && ...))
+        : cols{std::forward<Args>(args)...} {}
+
+    // Element access.
+    [[nodiscard]] constexpr VecType &operator[](std::size_t col) noexcept { return cols[col]; }
+    [[nodiscard]] constexpr const VecType &operator[](std::size_t col) const noexcept { return cols[col]; }
+    [[nodiscard]] constexpr T &operator()(std::size_t col, std::size_t row) noexcept { return cols[col][row]; }
+    [[nodiscard]] constexpr const T &operator()(std::size_t col, std::size_t row) const noexcept {
+        return cols[col][row];
+    }
+
+    // Assignment operators (return Derived&).
+    constexpr Derived &operator+=(const Derived &other) noexcept {
+        for (std::size_t j = 0; j < N; ++j) {
+            cols[j] += other[j];
+        }
+        return derived();
+    }
+
+    constexpr Derived &operator-=(const Derived &other) noexcept {
+        for (std::size_t j = 0; j < N; ++j) {
+            cols[j] -= other[j];
+        }
+        return derived();
+    }
+
+    constexpr Derived &operator/=(const T &scalar) {
+        if (VecType::is_zero(scalar))
+            throw std::invalid_argument("Division by zero in Mat.");
+
+        for (auto &col : cols) {
+            col /= scalar;
+        }
+        return derived();
+    }
+
+    constexpr Derived &operator*=(const T &scalar) noexcept {
+        for (auto &col : cols) {
+            col *= scalar;
+        }
+        return derived();
+    }
+
+    // Arithmetic operators (return Derived).
+    [[nodiscard]] constexpr Derived operator+(const Derived &other) const noexcept {
+        Derived result = derived();
+        result += other;
+        return result;
+    }
+
+    [[nodiscard]] constexpr Derived operator-(const Derived &other) const noexcept {
+        Derived result = derived();
+        result -= other;
+        return result;
+    }
+
+    [[nodiscard]] constexpr Derived operator/(const T &scalar) const {
+        Derived result = derived();
+        result /= scalar;
+        return result;
+    }
+
+    [[nodiscard]] constexpr Derived operator*(const T &scalar) const noexcept {
+        Derived result = derived();
+        result *= scalar;
+        return result;
+    }
+
+    [[nodiscard]] constexpr Derived operator*(const Derived &other) const noexcept {
+        Derived result;
+        for (std::size_t j = 0; j < N; ++j) {
+            for (std::size_t i = 0; i < N; ++i) {
+                T sum = T{0};
+                for (std::size_t k = 0; k < N; ++k) {
+                    sum += (*this)(k, i) * other(j, k);
+                }
+                result(j, i) = sum;
+            }
+        }
+        return result;
+    }
+
+    [[nodiscard]] constexpr VecType operator*(const VecType &vec) const noexcept {
+        VecType result;
+        for (std::size_t i = 0; i < N; ++i) {
+            T sum = T{0};
+            for (std::size_t j = 0; j < N; ++j) {
+                sum += (*this)(j, i) * vec[j];
+            }
+            result[i] = sum;
+        }
+        return result;
+    }
+
+    // Getters.
+    [[nodiscard]] constexpr const T &get_elem(std::size_t row, std::size_t col) const {
+        if (col >= N || row >= VecType::size())
+            throw std::out_of_range("Mat element indices out of range.");
+
+        return (*this)(col, row);
+    }
+
+    [[nodiscard]] constexpr const VecType &get_col(std::size_t idx) const {
+        if (idx >= N)
+            throw std::out_of_range("Mat column index out of range.");
+
+        return cols[idx];
+    }
+
+    [[nodiscard]] constexpr VecType get_row(std::size_t idx) const {
+        if (idx >= VecType::size())
+            throw std::out_of_range("Mat row index out of range.");
+
+        VecType vec;
+        for (std::size_t j = 0; j < N; ++j) {
+            vec[j] = (*this)(j, idx);
+        }
+        return vec;
+    }
+
+    // Setters.
+    constexpr void set_elem(std::size_t row, std::size_t col, T val) noexcept { (*this)(col, row) = val; }
+
+    constexpr void set_col(std::size_t idx, const VecType &col) noexcept { cols[idx] = col; }
+
+    constexpr void set_row(std::size_t idx, const VecType &row) noexcept {
+        for (std::size_t j = 0; j < N; ++j) {
+            (*this)(j, idx) = row[j];
+        }
+    }
+
+    // Transpose the matrix.
+    [[nodiscard]] constexpr Derived transpose() const noexcept {
+        Derived result;
+        for (std::size_t j = 0; j < N; ++j)
+            for (std::size_t i = 0; i < N; ++i) result(j, i) = (*this)(i, j);
+        return result;
+    }
+
+protected:
+    std::array<VecType, N> cols{};
+
+    // CRTP helper to get derived instance.
+    [[nodiscard]] constexpr Derived &derived() noexcept { return static_cast<Derived &>(*this); }
+    [[nodiscard]] constexpr const Derived &derived() const noexcept { return static_cast<const Derived &>(*this); }
+};
+}  // namespace vec_base

--- a/shaders/MotionBlur_K.frag
+++ b/shaders/MotionBlur_K.frag
@@ -5,7 +5,7 @@ in vec2 TexCoord;
 layout(location = 0) out vec4 FragColor;
 
 uniform sampler2D texture0;
-uniform vec2 resolution;
+uniform vec2 res;
 uniform vec2 pivot;
 uniform int mix_orig_img;
 uniform ivec2 samp;
@@ -14,88 +14,86 @@ uniform vec2 step_pos_offset;
 uniform float step_scale_offset;
 uniform mat2 step_rot_mat_offset;
 
-uniform mat3 htm_init_seg1;
-uniform mat3 adj_seg1;
+uniform mat3 init_htm_seg1;
+uniform mat3 init_htm_seg2;
 
-uniform mat3 htm_init_seg2;
-uniform mat3 adj_seg2;
-
+const float EPSILON = 1.0e-6;
 
 // Clamp the texture coordinates to avoid sampling outside the texture bounds.
 vec4
 safe_texture(in vec2 uv) {
-    if (uv.x < 0.0 || uv.x > resolution.x || uv.y < 0.0 || uv.y > resolution.y) {
-        return vec4(0.0);
-    }
-    return texture(texture0, uv / resolution);
+    vec2 coord = uv / res;
+    vec2 is_inside = step(vec2(0.0), coord) * step(coord, vec2(1.0));
+    float mask = is_inside.x * is_inside.y;
+    return mix(vec4(0.0), texture(texture0, coord), mask);
 }
 
 // Blur the texture using the given parameters.
-int
-blur(inout vec3 uv3, inout vec4 col, in int samp, in mat3 htm_init, in mat3 adj) {
-    int samp_cnt = 0;
-
-    mat3 htm = htm_init;
+void
+apply_blur(inout vec3 uv3, inout vec4 col, in int samp, in mat3 init_htm) {
+    mat3 htm = init_htm;
+    mat3 adj_mat = init_htm;
+    adj_mat[2] = vec3(0.0, 0.0, 1.0);
+    
     for (int i = 1; i <= samp; ++i) {
         uv3 = htm * uv3;
 
-        vec4 step_col = safe_texture(uv3.st + pivot);
-        step_col.rgb *= step_col.a;
-        col += step_col;
+        vec4 samp_col = safe_texture(uv3.st + pivot);
+        samp_col.rgb *= samp_col.a;
+        col += samp_col;
 
-        htm[2] = adj * htm[2];
-        samp_cnt++;
+        htm[2] = adj_mat * htm[2];
     }
-
-    return samp_cnt;
 }
 
 // Guessed AviUtl's normal blend.
 vec4
-blend(in vec4 col1, in vec4 col2) {
+blend(in vec4 col_base, in vec4 col_blend) {
     vec4 result;
 
-    float t = 1.0 - col2.a;
-    float w1 = col1.a * t;
-    float w2 = col2.a * col2.a;
-    float denominator = w1 + w2;
-    float is_zero = step(denominator, 0.0);
-    vec3 blend_result = (col1.rgb * w1 + col2.rgb * w2) / max(denominator, 1.0e-4);
-    result.rgb = mix(blend_result, vec3(0.0), is_zero);
+    float w_base = col_base.a * (1.0 - col_blend.a);
+    float w_blend = col_blend.a * col_blend.a;
+    float total_w = w_base + w_blend;
 
-    result.a = col1.a + col2.a * (1.0 - col1.a);
+    float is_zero = step(total_w, EPSILON);
+    vec3 mixed_rgb = (col_base.rgb * w_base + col_blend.rgb * w_blend) / max(total_w, EPSILON);
+    result.rgb = mix(mixed_rgb, vec3(0.0), is_zero);
+    result.a = col_base.a + col_blend.a * (1.0 - col_base.a);
 
     return clamp(result, 0.0, 1.0);
 }
 
 void
 main() {
-    vec2 uv = TexCoord * resolution - pivot;
+    vec2 uv = TexCoord * res - pivot;
     uv *= step_scale_offset;
     uv += step_pos_offset;
     uv = step_rot_mat_offset * uv;
+
     vec4 col = safe_texture(uv + pivot);
     col.rgb *= col.a;
 
-    int samp_cnt = 1;
+    int total_samp = 1;
+
+    // Apply blur.
     vec3 uv3 = vec3(uv, 1.0);
-    samp_cnt += blur(uv3, col, samp[0], htm_init_seg1, adj_seg1);
+    apply_blur(uv3, col, samp[0], init_htm_seg1);
+    total_samp += samp[0];
     if (samp[1] != 0) {
-        samp_cnt += blur(uv3, col, samp[1], htm_init_seg2, adj_seg2);
+        apply_blur(uv3, col, samp[1], init_htm_seg2);
+        total_samp += samp[1];
     }
-    uv = uv3.st;
 
     // Avoid division by zero.
-    // Division by zero can occur when the sample count is small, and the blur width is large.
-    // When division by zero occurs, the blend function (alpha mix) used later for blending the original image can't operate correctly.
-    // This is likely because the resulting value becomes infinity.
-    float is_zero = step(col.a, 0.0);
-    col.rgb = mix(col.rgb / max(col.a, 1.0e-4), vec3(0.0), is_zero); // 
-    col.a /= samp_cnt;
+    float is_zero = step(col.a, EPSILON);
+    col.rgb = mix(col.rgb / max(col.a, EPSILON), vec3(0.0), is_zero);
+    col.a /= float(total_samp);
     col = clamp(col, 0.0, 1.0);
-    // Blend the original image with the blurred image if is_orig_img_visible is true.
+
+    // Blend the original image with the blurred image.
     if (bool(mix_orig_img)) {
         col = blend(col, texture(texture0, TexCoord));
     }
+
     FragColor = col;
 }

--- a/shaders/MotionBlur_K.frag
+++ b/shaders/MotionBlur_K.frag
@@ -7,66 +7,63 @@ layout(location = 0) out vec4 FragColor;
 uniform sampler2D texture0;
 uniform vec2 resolution;
 uniform vec2 pivot;
-uniform int is_orig_img_visible;
-uniform ivec2 samples;
+uniform int mix_orig_img;
+uniform ivec2 samp;
 
 uniform vec2 step_pos_offset;
 uniform float step_scale_offset;
 uniform mat2 step_rot_mat_offset;
 
-uniform vec2 step_pos_seg1;
-uniform float step_scale_seg1;
-uniform mat2 step_rot_mat_seg1;
+uniform mat3 htm_init_seg1;
+uniform mat3 adj_seg1;
 
-uniform vec2 step_pos_seg2;
-uniform float step_scale_seg2;
-uniform mat2 step_rot_mat_seg2;
+uniform mat3 htm_init_seg2;
+uniform mat3 adj_seg2;
 
 
 // Clamp the texture coordinates to avoid sampling outside the texture bounds.
 vec4
-safe_texture(in sampler2D tex, in vec2 uv, in vec2 resolution) {
+safe_texture(in vec2 uv) {
     if (uv.x < 0.0 || uv.x > resolution.x || uv.y < 0.0 || uv.y > resolution.y) {
         return vec4(0.0);
     }
-    return texture(tex, uv / resolution);
+    return texture(texture0, uv / resolution);
 }
 
 // Blur the texture using the given parameters.
 int
-blur(inout vec2 uv, inout vec4 color, in int samples, in vec2 step_pos, in float step_scale, in mat2 step_rot_mat) {
-    int sample_count = 0;
+blur(inout vec3 uv3, inout vec4 col, in int samp, in mat3 htm_init, in mat3 adj) {
+    int samp_cnt = 0;
 
-    vec2 localized_step_pos = step_pos;
-    for (int i = 1; i <= samples; i++) {
-        uv -= localized_step_pos;
-        uv *= step_rot_mat / step_scale;
+    mat3 htm = htm_init;
+    for (int i = 1; i <= samp; ++i) {
+        uv3 = htm * uv3;
 
-        vec4 step_color = safe_texture(texture0, uv + pivot, resolution);
-        step_color.rgb *= step_color.a;
-        color += step_color;
+        vec4 step_col = safe_texture(uv3.st + pivot);
+        step_col.rgb *= step_col.a;
+        col += step_col;
 
-        sample_count++;
-        localized_step_pos *= step_rot_mat / step_scale;
+        htm[2] = adj * htm[2];
+        samp_cnt++;
     }
 
-    return sample_count;
+    return samp_cnt;
 }
 
 // Guessed AviUtl's normal blend.
 vec4
-blend(in vec4 color1, in vec4 color2) {
+blend(in vec4 col1, in vec4 col2) {
     vec4 result;
 
-    float t = 1.0 - color2.a;
-    float w1 = color1.a * t;
-    float w2 = color2.a * color2.a;
+    float t = 1.0 - col2.a;
+    float w1 = col1.a * t;
+    float w2 = col2.a * col2.a;
     float denominator = w1 + w2;
     float is_zero = step(denominator, 0.0);
-    vec3 blend_result = (color1.rgb * w1 + color2.rgb * w2) / max(denominator, 0.0001);
+    vec3 blend_result = (col1.rgb * w1 + col2.rgb * w2) / max(denominator, 1.0e-4);
     result.rgb = mix(blend_result, vec3(0.0), is_zero);
 
-    result.a = color1.a + color2.a * (1.0 - color1.a);
+    result.a = col1.a + col2.a * (1.0 - col1.a);
 
     return clamp(result, 0.0, 1.0);
 }
@@ -77,27 +74,28 @@ main() {
     uv *= step_scale_offset;
     uv += step_pos_offset;
     uv = step_rot_mat_offset * uv;
-    vec4 color = safe_texture(texture0, uv + pivot, resolution);
-    color.rgb *= color.a;
+    vec4 col = safe_texture(uv + pivot);
+    col.rgb *= col.a;
 
-    int sample_count = 1;
-
-    sample_count += blur(uv, color, samples.x, step_pos_seg1, step_scale_seg1, step_rot_mat_seg1);
-    if (samples.y != 0) {
-        sample_count += blur(uv, color, samples.y, step_pos_seg2, step_scale_seg2, step_rot_mat_seg2);
+    int samp_cnt = 1;
+    vec3 uv3 = vec3(uv, 1.0);
+    samp_cnt += blur(uv3, col, samp[0], htm_init_seg1, adj_seg1);
+    if (samp[1] != 0) {
+        samp_cnt += blur(uv3, col, samp[1], htm_init_seg2, adj_seg2);
     }
+    uv = uv3.st;
 
     // Avoid division by zero.
     // Division by zero can occur when the sample count is small, and the blur width is large.
     // When division by zero occurs, the blend function (alpha mix) used later for blending the original image can't operate correctly.
     // This is likely because the resulting value becomes infinity.
-    float is_zero = step(color.a, 0.0);
-    color.rgb = mix(color.rgb / max(color.a, 0.0001), vec3(0.0), is_zero); // 
-    color.a /= sample_count;
-    color = clamp(color, 0.0, 1.0);
+    float is_zero = step(col.a, 0.0);
+    col.rgb = mix(col.rgb / max(col.a, 1.0e-4), vec3(0.0), is_zero); // 
+    col.a /= samp_cnt;
+    col = clamp(col, 0.0, 1.0);
     // Blend the original image with the blurred image if is_orig_img_visible is true.
-    if (bool(is_orig_img_visible)) {
-        color = blend(color, texture(texture0, TexCoord));
+    if (bool(mix_orig_img)) {
+        col = blend(col, texture(texture0, TexCoord));
     }
-    FragColor = color;
+    FragColor = col;
 }


### PR DESCRIPTION
Closes #4 

This pull request introduces 3×3 matrix support to improve the flexibility and accuracy of coordinate transformations within the system.

- Add `Mat3` class for 3×3 matrix representation.

- Add `Vec3` class to support homogeneous coordinate operations.

- Add `Mat2` class to maintain 2×2 matrix support where appropriate.

- Revise offset calculation logic to be consistent with 3×3 transformation handling and support translation, scaling, and rotation more robustly.